### PR TITLE
Vertex name, label, data

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here we keep a list of the roadmap for the development of this library. If you h
 - [ ] [Edge.setLabel](https://github.com/mlarocca/jsgraphs/issues/23)
 - [ ] [removeVertex()](https://github.com/mlarocca/jsgraphs/issues/20)
 - [ ] [removeEdge()](https://github.com/mlarocca/jsgraphs/issues/21)
+- [ ] Add label and data fields for vertices
 - [ ] Add options to display/hide vertex name/label
 - [ ] Union of 2 disjoint graphs
 - [ ] DFS returns all cycles found

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-graphs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JsGraphs library",
   "private": true,
   "scripts": {

--- a/readme/tutorial.md
+++ b/readme/tutorial.md
@@ -27,11 +27,17 @@ Class [`Vertex`](../src/graph/vertex.js) implement the first basic component of 
 ```javascript
 import Vertex from '/src/graph/vertex.mjs';
 
-const v = new Vertex('vertex name', {weight: 3});
 const u = new Vertex('u');
+const v = new Vertex('vertex name', {weight: 3, label: 'I am a label', data: [1, 2, 3]});
 ```
 
-Vertices in _JsGraphs_ are immutable, hence `u` and `v` above are real consts. On creation, you must add a name for the vertex, and optionally a weight: the default weight for a vertex is 1, and generally you don't have to worry about this weight, but some graph applications can use it.
+A vertex' name is forever, it can never be changed: it uniquely identify a vertex, and in fact a vertex' ID is computed from its name.
+
+On creation, you must add a name for the vertex, and optionally you can include:
+
+- A weight: the default weight for a vertex is 1, and generally you don't have to worry about this weight, but some graph applications can use it.
+- A label: an optional string that can be changed over time and used to convey non-identifying, mutable info about the vertex.
+- Data: this is the most generic field for a vertex, it can include any serializable object, even another graph: this way, for instance, it's possible to create meta-graphs (graphs where each vertex is another graph) and run specific algorithms where whenever a vertex is visited, the graph it holds is also traversed (one example could be the graph of strongly connected components: breaking G into its SCCs, and then representing it with a new meta-graph, the SCC graph, whose vertices hold the actual components).
 
 A vertex's name doesn't have to be a string, it can be any object that can be serialized to the `JSON` format: strings, numbers, arrays, plain JS objects, or custom objects that have a `toJson` method.
 
@@ -49,6 +55,8 @@ Vertex.isValidName(new Map());   // false
 Vertex.isValidName(new Set());   // false
 Vertex.isValidName(() => true));   // false, functions can't be serialized to JSON
 ```
+
+Likewise, there are methods `Vertex.isValidLabel` and `Vertex.isValidData`.
 
 Existing vertices can be added to graphs: notice that it's NOT possible to add two vertices with the same name to the same graph.
 

--- a/readme/tutorial.md
+++ b/readme/tutorial.md
@@ -27,30 +27,30 @@ Class [`Vertex`](../src/graph/vertex.js) implement the first basic component of 
 ```javascript
 import Vertex from '/src/graph/vertex.mjs';
 
-const v = new Vertex('vertex label', {weight: 3});
+const v = new Vertex('vertex name', {weight: 3});
 const u = new Vertex('u');
 ```
 
-Vertices in _JsGraphs_ are immutable, hence `u` and `v` above are real consts. On creation, you must add a label for the vertex, and optionally a weight: the default weight for a vertex is 1, and generally you don't have to worry about this weight, but some graph applications can use it.
+Vertices in _JsGraphs_ are immutable, hence `u` and `v` above are real consts. On creation, you must add a name for the vertex, and optionally a weight: the default weight for a vertex is 1, and generally you don't have to worry about this weight, but some graph applications can use it.
 
-A vertex's label doesn't have to be a string, it can be any object that can be serialized to the `JSON` format: strings, numbers, arrays, plain JS objects, or custom objects that have a `toJson` method.
+A vertex's name doesn't have to be a string, it can be any object that can be serialized to the `JSON` format: strings, numbers, arrays, plain JS objects, or custom objects that have a `toJson` method.
 
-It is possible to use the `static` method `Vertex.isValidLabel` to check if a value is a valid label:
+It is possible to use the `static` method `Vertex.isValidName` to check if a value is a valid name:
 
 ```javascript
-Vertex.isValidLabel(1);   // true
-Vertex.isValidLabel('abc');   // true
-Vertex.isValidLabel([1, 2, true, 'a']);   // true
-Vertex.isValidLabel({a: [1, 2, 3], b: {x: -1, y: 0.5}});   // true
-Vertex.isValidLabel(new Vertex('test'));   // true, Vertex has a toJson() method
-Vertex.isValidLabel(new Graph());   // true!! Graph has a toJson() method
+Vertex.isValidName(1);   // true
+Vertex.isValidName('abc');   // true
+Vertex.isValidName([1, 2, true, 'a']);   // true
+Vertex.isValidName({a: [1, 2, 3], b: {x: -1, y: 0.5}});   // true
+Vertex.isValidName(new Vertex('test'));   // true, Vertex has a toJson() method
+Vertex.isValidName(new Graph());   // true!! Graph has a toJson() method
 
-Vertex.isValidLabel(new Map());   // false
-Vertex.isValidLabel(new Set());   // false
-Vertex.isValidLabel(() => true));   // false, functions can't be serialized to JSON
+Vertex.isValidName(new Map());   // false
+Vertex.isValidName(new Set());   // false
+Vertex.isValidName(() => true));   // false, functions can't be serialized to JSON
 ```
 
-Existing vertices can be added to graphs: notice that it's NOT possible to add two vertices with the same label to the same graph.
+Existing vertices can be added to graphs: notice that it's NOT possible to add two vertices with the same name to the same graph.
 
 ```javascript
 let graph = new Graph();
@@ -69,7 +69,7 @@ There is also a shortcut to create those vertices directly on the graph, without
 ```javascript
 let graph = new Graph();
 
-const vId = graph.createVertex(['I', 'am', 'a', 'valid', 'label'], {weight: 3});
+const vId = graph.createVertex(['I', 'am', 'a', 'valid', 'name'], {weight: 3});
 const uId = graph.createVertex('u');
 // graph.createVertex('u) // ERROR, duplicated vertex 'u'
 ```
@@ -77,7 +77,7 @@ const uId = graph.createVertex('u');
 
 As you can see in the snippet above, `createVertex` (as well as `addVertex`) returns the ID of the vertex created (NOT a reference to the actual instance held by the graph).
 
-Each vertex, in fact, has an `id` property that uniquely identifies it in a graph: as mentioned, there can't be two vertices with the same label, so there is a 1:1 correspondence between labels and IDs. This means that the IDs of two instances of `Vertex` can clash even if they are different objects, or if they have different properties.
+Each vertex, in fact, has an `id` property that uniquely identifies it in a graph: as mentioned, there can't be two vertices with the same name, so there is a 1:1 correspondence between names and IDs. This means that the IDs of two instances of `Vertex` can clash even if they are different objects, or if they have different properties.
 
 ```javascript
 const u1 = new Vertex('u', {weight: 3});
@@ -110,7 +110,7 @@ Once you get ahold of a reference to a graph's vertex, you can read all its fiel
 
 
 >  Although having vertices as perfectly immutable entities would have been desirable, this would have had repercussions on the performance of the graph, because updating a vertex `v`'s weight would have meant replacing `v` in the graph with a new instance of `Vertex`, and also updating all the references to `v` in (potentially, up to ) all the edges in the graph.
-As a compromise, a vertex' label and id are kept immutable and impossible to change, while weight is mutable. Similar compromises will be made for embedded vertices and edges.
+As a compromise, a vertex' name and id are kept immutable and impossible to change, while weight is mutable. Similar compromises will be made for embedded vertices and edges.
 Switching to `TypeScript`, or whenever a future `EcmaScript` specification will include protected fields, would allow for more flexibility and possibly this aspect will be reviewed. For now, changing the mutable attributes of a graph's vertices and edges directly is **discouraged**: the **forward-compatible** way is going to be changing them through the `Graph` and `Embedding`'s methods.
 
 
@@ -124,7 +124,7 @@ Creating a new edge is as simple as creating a new vertex, except that we need t
 import Vertex from '/src/graph/vertex.mjs';
 import Edge from '/src/graph/edge.mjs';
 
-const v = new Vertex('vertex label', {weight: 3});
+const v = new Vertex('vertex name', {weight: 3});
 const u = new Vertex('u');
 
 const e = new Edge(u, v, {weight: 0.4, label: "I'm an edge!"});
@@ -212,7 +212,7 @@ e = g.getEdgeBetween(u.id, v);
 Last but not least, so far we have always assumed that source and destination of an edge are distinct: this doesn't necessarily need to be true. In other words, it's possible to have an edge starting from and ending to the same vertex: in this case, the edge is called a loop.
 
 ```javascript
-let loop = g.getEdgeBetween(u, u, {label: 'Loop'});
+let loop = g.createEdge(u, u, {label: 'Loop'});
 ```
 
 ![An edge and a loop](./img/tutorial/tutorial_edge_3.jpg)
@@ -246,7 +246,7 @@ let g = Graph.completeGraph(12);
 let ug = UndirectedGraph.completeGraph(12);
 ```
 
-Of course, the labels for the vertices are standard, just the numbers between 1 and n.
+Of course, the names for the vertices are standard, just the numbers between 1 and n.
 The representation of such graphs is cool for both directed and undirected ones:
 
 ![A complete directed Graph](./img/tutorial/tutorial_graph_complete_1.jpg)![A complete undirected Graph](./img/tutorial/tutorial_graph_complete_2.jpg)
@@ -284,7 +284,7 @@ let g = new Graph();
 const json = g.toJson();
 let g1 = Graph.fromJSON(json);
 ```
-This is an important property (and the reason why we restricted the type of valid labels), because it allows you to create a graph in any other platform/language, possibly run algorithms or transformations on it, and then export it to a _JSON_ file, pick it up in you web app with _JsGraphs_, and display it.
+This is an important property (and the reason why we restricted the type of valid names), because it allows you to create a graph in any other platform/language, possibly run algorithms or transformations on it, and then export it to a _JSON_ file, pick it up in you web app with _JsGraphs_, and display it.
 
 Or, vice versa, create it in JS (perhaps with an ad-hoc tool: stay tuned!), and then import it in your application written in any other language, or just store it in a **database** and retrieve it later.
 

--- a/readme/tutorial.md
+++ b/readme/tutorial.md
@@ -39,24 +39,34 @@ On creation, you must add a name for the vertex, and optionally you can include:
 - A label: an optional string that can be changed over time and used to convey non-identifying, mutable info about the vertex.
 - Data: this is the most generic field for a vertex, it can include any serializable object, even another graph: this way, for instance, it's possible to create meta-graphs (graphs where each vertex is another graph) and run specific algorithms where whenever a vertex is visited, the graph it holds is also traversed (one example could be the graph of strongly connected components: breaking G into its SCCs, and then representing it with a new meta-graph, the SCC graph, whose vertices hold the actual components).
 
-A vertex's name doesn't have to be a string, it can be any object that can be serialized to the `JSON` format: strings, numbers, arrays, plain JS objects, or custom objects that have a `toJson` method.
+A vertex's name can either be a string or a number: any other type will be considered invalid.
 
 It is possible to use the `static` method `Vertex.isValidName` to check if a value is a valid name:
 
 ```javascript
 Vertex.isValidName(1);   // true
 Vertex.isValidName('abc');   // true
-Vertex.isValidName([1, 2, true, 'a']);   // true
-Vertex.isValidName({a: [1, 2, 3], b: {x: -1, y: 0.5}});   // true
-Vertex.isValidName(new Vertex('test'));   // true, Vertex has a toJson() method
-Vertex.isValidName(new Graph());   // true!! Graph has a toJson() method
-
+Vertex.isValidName([1, 2, true, 'a']);   // false
+Vertex.isValidName({a: [1, 2, 3], b: {x: -1, y: 0.5}});   // false
 Vertex.isValidName(new Map());   // false
-Vertex.isValidName(new Set());   // false
-Vertex.isValidName(() => true));   // false, functions can't be serialized to JSON
+Vertex.isValidName(new Vertex('test'));   // false
 ```
 
-Likewise, there are methods `Vertex.isValidLabel` and `Vertex.isValidData`.
+Likewise, there are methods `Vertex.isValidLabel` and `Vertex.isValidData`. Labels must be strings (they are optional, so `null` and `undefined` are accepted to encode the absence of a value, and the empty string is also a valid label).
+Data, instead, doesn't have to be a string, it can be any object that can be serialized to the `JSON` format: strings, numbers, arrays, plain JS objects, or custom objects that have a `toJson()` method.
+
+```javascript
+Vertex.isValidData(1);   // true
+Vertex.isValidData('abc');   // true
+Vertex.isValidData([1, 2, true, 'a']);   // true
+Vertex.isValidData({a: [1, 2, 3], b: {x: -1, y: 0.5}});   // true
+Vertex.isValidData(new Vertex('test'));   // true, Vertex has a toJson() method
+Vertex.isValidData(new Graph());   // true!! Graph has a toJson() method
+
+Vertex.isValidData(new Map());   // false
+Vertex.isValidData(new Set());   // false
+Vertex.isValidData(() => true));   // false, functions can't be serialized to JSON
+```
 
 Existing vertices can be added to graphs: notice that it's NOT possible to add two vertices with the same name to the same graph.
 

--- a/src/common/errors.mjs
+++ b/src/common/errors.mjs
@@ -23,8 +23,9 @@ export const ERROR_MSG_RANGE_TOO_LARGE = (fname, a, b) => `Illegal argument for 
 export const ERROR_MSG_RANDOM_STRING_LENGTH = val => `Illegal argument for randomString: length = ${val} must be a non-negative SafeInteger`;
 export const ERROR_MSG_RANDOM_STRING_TOO_LARGE = val => `Illegal argument for randomString: length ${val} is too large to be allocated`;
 // graph
-export const ERROR_MSG_INVALID_LABEL = (fname, val) => `Invalid label in method ${fname}: ${val} is not JSON-serializable`;
-export const ERROR_MSG_INVALID_EDGE_LABEL = (fname, val) => `Invalid label in method ${fname}: ${val}. Edge labels must be strings.`;
+export const ERROR_MSG_INVALID_NAME = (fname, val) => `Invalid name in method ${fname}: ${val}. Only strings and numbers are allowed.`;
+export const ERROR_MSG_INVALID_DATA = (fname, val) => `Invalid data in method ${fname}: ${val} is not JSON-serializable`;
+export const ERROR_MSG_INVALID_LABEL = (fname, val) => `Invalid label in method ${fname}: ${val}. Labels must be strings.`;
 export const ERROR_MSG_EDGE_NOT_FOUND = (fname, val) => `Illegal parameter for ${fname}: Edge ${val} not in graph`;
 export const ERROR_MSG_VERTEX_NOT_FOUND = (fname, val) => `Illegal parameter for ${fname}: Vertex ${val} not in graph`;
 export const ERROR_MSG_VERTEX_DUPLICATED = (fname, val) => `Illegal argument for  ${fname}: v = ${val}: is already in the graph.`;

--- a/src/graph/edge.mjs
+++ b/src/graph/edge.mjs
@@ -3,7 +3,7 @@ import Vertex from './vertex.mjs'
 import { isDefined } from '../common/basic.mjs';
 import { isNumber, toNumber } from '../common/numbers.mjs';
 import { consistentStringify, isString } from '../common/strings.mjs';
-import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_EDGE_LABEL } from '../common/errors.mjs';
+import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_LABEL } from '../common/errors.mjs';
 import { isNonEmptyString } from '../common/strings.mjs';
 
 import escape from 'escape-html';
@@ -87,7 +87,7 @@ class Edge {
       label = undefined;
     }
     if (isDefined(label) && !(isString(label))) {
-      throw new TypeError(ERROR_MSG_INVALID_EDGE_LABEL('Edge()', label));
+      throw new TypeError(ERROR_MSG_INVALID_LABEL('Edge()', label));
     }
 
     this.#source = source;
@@ -153,7 +153,7 @@ class Edge {
    * @return {Edge} The transposed edge.
    */
   transpose() {
-    return new Edge(this.#destination, this.#source, {weight: this.#weight, label: this.#label});
+    return new Edge(this.#destination, this.#source, { weight: this.#weight, label: this.#label });
   }
 
   toJson() {

--- a/src/graph/edge.mjs
+++ b/src/graph/edge.mjs
@@ -52,7 +52,7 @@ class Edge {
   }
 
   static fromJsonObject({ source, destination, weight = DEFAULT_EDGE_WEIGHT, label = undefined }) {
-    return new Edge(Vertex.fromJsonObject(source), Vertex.fromJsonObject(destination), { weight: weight, label: label });
+    return new Edge(Vertex.fromJsonObject(source), Vertex.fromJsonObject(destination), { weight: weight, label: label ?? undefined });
   }
 
   /**

--- a/src/graph/embedding/embedded_edge.mjs
+++ b/src/graph/embedding/embedded_edge.mjs
@@ -29,7 +29,7 @@ class EmbeddedEdge extends Edge {
       EmbeddedVertex.fromJsonObject(destination),
       {
         weight: weight,
-        label: label,
+        label: label ?? undefined,
         isDirected: isDirected,
         arcControlDistance: arcControlDistance
       });

--- a/src/graph/embedding/embedded_vertex.mjs
+++ b/src/graph/embedding/embedded_vertex.mjs
@@ -23,12 +23,12 @@ class EmbeddedVertex extends Vertex {
   /**
    * @static
    */
-  static fromJsonObject({ label, position, weight = null }) {
-    return new EmbeddedVertex(label, Point2D.fromJson(position), { weight: weight });
+  static fromJsonObject({ name, position, weight = null }) {
+    return new EmbeddedVertex(name, Point2D.fromJson(position), { weight: weight });
   }
 
-  constructor(label, vertexPosition, { weight } = {}) {
-    super(label, { weight: weight });
+  constructor(name, vertexPosition, { weight } = {}) {
+    super(name, { weight: weight });
     if (!(vertexPosition instanceof Point2D) || vertexPosition.dimensionality < 2) {
       throw new Error(ERROR_MSG_INVALID_ARGUMENT('EmbeddedVertex()', 'vertexPosition', vertexPosition));
     }
@@ -55,12 +55,12 @@ class EmbeddedVertex extends Vertex {
   }
 
   clone() {
-    return new EmbeddedVertex(this.label, this.position, { weight: this.weight });
+    return new EmbeddedVertex(this.name, this.position, { weight: this.weight });
   }
 
   toJsonObject() {
     return {
-      label: this.label,
+      name: this.name,
       weight: this.weight,
       position: this._center.toJson()
     };
@@ -75,7 +75,7 @@ class EmbeddedVertex extends Vertex {
     return `
     <g class="vertex ${cssClasses.join(' ')}" transform="translate(${Math.round(x)},${Math.round(y)})">
       <circle cx="0" cy="0" r="${Math.round(this.radius())}" />
-      <text x="0" y="0" text-anchor="middle" dominant-baseline="central">${this.escapedLabel}</text>
+      <text x="0" y="0" text-anchor="middle" dominant-baseline="central">${this.escapedName}</text>
     </g>`;
   }
 }

--- a/src/graph/embedding/embedded_vertex.mjs
+++ b/src/graph/embedding/embedded_vertex.mjs
@@ -23,12 +23,12 @@ class EmbeddedVertex extends Vertex {
   /**
    * @static
    */
-  static fromJsonObject({ name, position, weight = null }) {
-    return new EmbeddedVertex(name, Point2D.fromJson(position), { weight: weight });
+  static fromJsonObject({ name, position, weight = null, label, data }) {
+    return new EmbeddedVertex(name, Point2D.fromJson(position), { weight: weight, label: label, data: data });
   }
 
-  constructor(name, vertexPosition, { weight } = {}) {
-    super(name, { weight: weight });
+  constructor(name, vertexPosition, { weight, label, data } = {}) {
+    super(name, { weight: weight, label: label, data: data });
     if (!(vertexPosition instanceof Point2D) || vertexPosition.dimensionality < 2) {
       throw new Error(ERROR_MSG_INVALID_ARGUMENT('EmbeddedVertex()', 'vertexPosition', vertexPosition));
     }
@@ -55,15 +55,13 @@ class EmbeddedVertex extends Vertex {
   }
 
   clone() {
-    return new EmbeddedVertex(this.name, this.position, { weight: this.weight });
+    return new EmbeddedVertex(this.name, this.position, { weight: this.weight, label: this.label, data: this.data });
   }
 
   toJsonObject() {
-    return {
-      name: this.name,
-      weight: this.weight,
-      position: this._center.toJson()
-    };
+    let json = super.toJsonObject();
+    json['position'] = this._center.toJson();
+    return json;
   }
 
   toString() {

--- a/src/graph/embedding/embedded_vertex.mjs
+++ b/src/graph/embedding/embedded_vertex.mjs
@@ -24,7 +24,7 @@ class EmbeddedVertex extends Vertex {
    * @static
    */
   static fromJsonObject({ name, position, weight = null, label, data }) {
-    return new EmbeddedVertex(name, Point2D.fromJson(position), { weight: weight, label: label, data: data });
+    return new EmbeddedVertex(name, Point2D.fromJson(position), { weight: weight, label: label ?? undefined, data: data ?? undefined });
   }
 
   constructor(name, vertexPosition, { weight, label, data } = {}) {

--- a/src/graph/embedding/embedding.mjs
+++ b/src/graph/embedding/embedding.mjs
@@ -56,7 +56,7 @@ class Embedding {
       if (!(cs instanceof Point2D)) {
         cs = Point2D.random({ width, height });
       }
-      let eV = new EmbeddedVertex(v.label, cs, { weight: v.weight });
+      let eV = new EmbeddedVertex(v.name, cs, { weight: v.weight });
       vertices.set(eV.id, eV);
     }
 
@@ -92,7 +92,7 @@ class Embedding {
 
     let coordinates = {};
     for (const v of g.vertices) {
-      const i = toNumber(v.label) - 1;
+      const i = toNumber(v.name) - 1;
       const delta = 2 * Math.PI / n;
       const center = canvasSize / 2;
       const radius = center - EmbeddedVertex.DEFAULT_VERTEX_RADIUS;
@@ -125,7 +125,7 @@ class Embedding {
     let x, y;
 
     for (const v of g.vertices) {
-      const i = toNumber(v.label);
+      const i = toNumber(v.name);
       if (i <= n) {
         x = 2 * EmbeddedVertex.DEFAULT_VERTEX_RADIUS;
         y = EmbeddedVertex.DEFAULT_VERTEX_RADIUS + (i - 1) * deltaN;

--- a/src/graph/graph.mjs
+++ b/src/graph/graph.mjs
@@ -27,15 +27,15 @@ class MutableVertex extends Vertex {
    *
    * Construct an object representation for a graph's vertex.
    *
-   * @param {*} label  The vertex's label.
+   * @param {*} name  The vertex's name.
    * @param {number?} weight  The weight associated to the vertex (by default, 1).
    * @param {array<Edge>?} outgoingEdges  An optional array of outgoing edges from this vertices.
    * @return {MutableVertex}  The Vertex created.
-   * @throws {TypeError} if the arguments are not valid, i.e. label is not defined, weight is not
+   * @throws {TypeError} if the arguments are not valid, i.e. name is not defined, weight is not
    *                     (parseable to) a number, or outgoingEdges is not a valid array of Edges.
    */
-  constructor(label, { weight, outgoingEdges = [] } = {}) {
-    super(label, { weight: weight });
+  constructor(name, { weight, outgoingEdges = [] } = {}) {
+    super(name, { weight: weight });
     if (!Array.isArray(outgoingEdges)) {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('GVertex constructor', 'outgoingEdges', outgoingEdges));
     }
@@ -124,7 +124,7 @@ class MutableVertex extends Vertex {
    * @override
    */
   clone() {
-    return new MutableVertex(this.label, { weight: this.weight });
+    return new MutableVertex(this.name, { weight: this.weight });
   }
 
   /**
@@ -141,9 +141,8 @@ class MutableVertex extends Vertex {
  * @for GVertex
  * @private
  *
- * @param adj
+ * @param {Array[Vertex]} adj
  * @param {Vertex} destination
- * @param {*?} label
  * @param {Edge} newEdge  The edge with whom the old one needs to be replaced. If null or undefined, it will
  *                        remove the old edge.
  */
@@ -303,12 +302,12 @@ class Graph {
     return this.vertices.length === 0;
   }
 
-  createVertex(label, { weight } = {}) {
-    if (this.hasVertex(Vertex.idFromLabel(label))) {
-      throw new Error(ERROR_MSG_VERTEX_DUPLICATED('Graph.createVertex', label));
+  createVertex(name, { weight } = {}) {
+    if (this.hasVertex(Vertex.idFromName(name))) {
+      throw new Error(ERROR_MSG_VERTEX_DUPLICATED('Graph.createVertex', name));
     }
 
-    const v = new MutableVertex(label, { weight: weight });
+    const v = new MutableVertex(name, { weight: weight });
 
     let vcs = _vertices.get(this);
     vcs.set(v.id, v);
@@ -327,7 +326,7 @@ class Graph {
       throw new Error(ERROR_MSG_VERTEX_DUPLICATED('Graph.addVertex', vertex));
     }
 
-    const v = new MutableVertex(vertex.label, { weight: vertex.weight });
+    const v = new MutableVertex(vertex.name, { weight: vertex.weight });
     vcs.set(vertex.id, v);
     _vertices.set(this, vcs);
 
@@ -479,21 +478,21 @@ class Graph {
 
   /**
    * Shortcut to avoid edge cloning
-   * @param {*} sourceLabel
-   * @param {*} destinationLabel
+   * @param {*} sourceName
+   * @param {*} destinationName
    */
-  getEdgeWeight(sourceLabel, destinationLabel) {
-    const e = getGraphEdge(this, sourceLabel, destinationLabel);
+  getEdgeWeight(sourceName, destinationName) {
+    const e = getGraphEdge(this, sourceName, destinationName);
     return e?.weight;
   }
 
   /**
    * Shortcut to avoid edge cloning
-   * @param {*} sourceLabel
-   * @param {*} destinationLabel
+   * @param {*} sourceName
+   * @param {*} destinationName
    */
-  getEdgeLabel(sourceLabel, destinationLabel) {
-    const e = getGraphEdge(this, sourceLabel, destinationLabel);
+  getEdgeLabel(sourceName, destinationName) {
+    const e = getGraphEdge(this, sourceName, destinationName);
     return e?.label;
   }
 

--- a/src/graph/vertex.mjs
+++ b/src/graph/vertex.mjs
@@ -17,27 +17,27 @@ class Vertex {
   /**
    * @private
    */
-  #label;
+  #name;
 
   /**
    * @private
    */
   #weight;
 
-  static isValidLabel(label) {
-    return isJsonStringifiable(label);
+  static isValidName(name) {
+    return isJsonStringifiable(name);
   }
 
-  static idFromLabel(label) {
-    return consistentStringify(label);
+  static idFromName(name) {
+    return consistentStringify(name);
   }
 
   static fromJson(json) {
     return Vertex.fromJsonObject(JSON.parse(json));
   }
 
-  static fromJsonObject({ label, weight = DEFAULT_VERTEX_WEIGHT }) {
-    return new Vertex(label, { weight: weight });
+  static fromJsonObject({ name, weight = DEFAULT_VERTEX_WEIGHT }) {
+    return new Vertex(name, { weight: weight });
   }
 
   /**
@@ -46,41 +46,48 @@ class Vertex {
    *
    * Construct an object representation for a graph's vertex.
    *
-   * @param {*} label  The vertex's label.
+   * @param {*} name  The vertex's name.
    * @param {number?} weight  The weight associated to the vertex (by default, 1).
    * @return {Vertex}  The Vertex created.
-   * @throws {TypeError} if the arguments are not valid, i.e. label is not defined, or weight is not
+   * @throws {TypeError} if the arguments are not valid, i.e. name is not defined, or weight is not
    *                     (parseable to) a number.
    */
-  constructor(label, { weight = DEFAULT_VERTEX_WEIGHT } = {}) {
-    if (!isDefined(label)) {
-      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', label));
+  constructor(name, { weight = DEFAULT_VERTEX_WEIGHT } = {}) {
+    if (!isDefined(name)) {
+      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', name));
     }
-    if (!Vertex.isValidLabel(label)) {
-      throw new TypeError(ERROR_MSG_INVALID_LABEL('Vertex()', label));
+    if (!Vertex.isValidName(name)) {
+      throw new TypeError(ERROR_MSG_INVALID_LABEL('Vertex()', name));
     }
     if (!isNumber(weight)) {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'weight', weight));
     }
 
-    // Deep clone label
-    this.#label = deepClone(label);
+    // Deep clone name
+    this.#name = deepClone(name);
     this.#weight = toNumber(weight);
   }
 
-  get label() {
-    return deepClone(this.#label);
+  get name() {
+    return deepClone(this.#name);
   }
 
   /**
-   * HTML-escaped string from label
+   * HTML-escaped string for name
+   */
+  get escapedName() {
+    return escape(this.#name.toString());
+  }
+
+  /**
+   * HTML-escaped string from name
    */
   get escapedLabel() {
-    return escape(this.#label.toString());
+    return escape(this.#name.toString());
   }
 
   get id() {
-    return Vertex.idFromLabel(this.label);
+    return Vertex.idFromName(this.name);
   }
 
   get weight() {
@@ -100,7 +107,7 @@ class Vertex {
 
   toJsonObject() {
     return {
-      label: this.label,
+      name: this.name,
       weight: this.weight
     };
   }
@@ -120,11 +127,11 @@ class Vertex {
 
   /**
   /**
-   * Clones a vertex, copying over the label and weight, NOT the adjacency map.
+   * Clones a vertex, copying over the name and weight, NOT the adjacency map.
    *
    */
   clone() {
-    return new Vertex(this.label, { weight: this.weight });
+    return new Vertex(this.name, { weight: this.weight });
   }
 }
 

--- a/src/graph/vertex.mjs
+++ b/src/graph/vertex.mjs
@@ -46,7 +46,7 @@ class Vertex {
   }
 
   static isValidLabel(label) {
-    return isString(label);
+    return !isDefined(label) || isString(label);
   }
 
   static idFromName(name) {
@@ -58,7 +58,7 @@ class Vertex {
   }
 
   static fromJsonObject({ name, weight = DEFAULT_VERTEX_WEIGHT, label, data }) {
-    return new Vertex(name, { weight: weight, label: label, data: data });
+    return new Vertex(name, { weight: weight, label: label ?? undefined, data: data ?? undefined });
   }
 
   /**

--- a/src/graph/vertex.mjs
+++ b/src/graph/vertex.mjs
@@ -1,7 +1,7 @@
 import { isDefined } from '../common/basic.mjs';
 import { isNumber, toNumber } from '../common/numbers.mjs';
-import { consistentStringify, isJsonStringifiable, isString } from '../common/strings.mjs';
-import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_LABEL } from '../common/errors.mjs';
+import { consistentStringify, isJsonStringifiable, isString, isNonEmptyString } from '../common/strings.mjs';
+import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_DATA, ERROR_MSG_INVALID_LABEL, ERROR_MSG_INVALID_NAME } from '../common/errors.mjs';
 
 import rfdc from 'rfdc';
 import escape from 'escape-html';
@@ -38,7 +38,7 @@ class Vertex {
   #data
 
   static isValidName(name) {
-    return isJsonStringifiable(name);
+    return isNonEmptyString(name) || isNumber(name);
   }
 
   static isValidData(data) {
@@ -78,23 +78,23 @@ class Vertex {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', name));
     }
     if (!Vertex.isValidName(name)) {
-      throw new TypeError(ERROR_MSG_INVALID_LABEL('Vertex()', name));
+      throw new TypeError(ERROR_MSG_INVALID_NAME('Vertex()', name));
     }
     if (!isNumber(weight)) {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'weight', weight));
     }
     if (isDefined(label) && !Vertex.isValidLabel(label)) {
-      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', label));
+      throw new TypeError(ERROR_MSG_INVALID_LABEL('Vertex()', label));
     }
     if (isDefined(data) && !Vertex.isValidData(data)) {
-      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'data', data));
+      throw new TypeError(ERROR_MSG_INVALID_DATA('Vertex()', data));
     }
 
     // Deep clone name
-    this.#name = deepClone(name);
+    this.#name = name;
     this.#weight = toNumber(weight);
     this.#label = label;
-    this.#data = data;
+    this.#data = deepClone(data);
   }
 
   get name() {
@@ -197,7 +197,7 @@ class Vertex {
    *
    */
   clone() {
-    return new Vertex(this.name, { weight: this.weight, data: this.data, label: this.label});
+    return new Vertex(this.name, { weight: this.weight, data: this.data, label: this.label });
   }
 }
 

--- a/src/graph/vertex.mjs
+++ b/src/graph/vertex.mjs
@@ -1,6 +1,6 @@
 import { isDefined } from '../common/basic.mjs';
 import { isNumber, toNumber } from '../common/numbers.mjs';
-import { consistentStringify, isJsonStringifiable } from '../common/strings.mjs';
+import { consistentStringify, isJsonStringifiable, isString } from '../common/strings.mjs';
 import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_LABEL } from '../common/errors.mjs';
 
 import rfdc from 'rfdc';
@@ -16,16 +16,37 @@ const deepClone = rfdc({ proto: true, circles: false });
 class Vertex {
   /**
    * @private
+   * {*}
    */
   #name;
 
   /**
    * @private
+   * {number}
    */
   #weight;
 
+  /**
+   * {string}
+   * @private
+   */
+  #label
+
+  /**
+   * {*}
+   */
+  #data
+
   static isValidName(name) {
     return isJsonStringifiable(name);
+  }
+
+  static isValidData(data) {
+    return isJsonStringifiable(data);
+  }
+
+  static isValidLabel(label) {
+    return isString(label);
   }
 
   static idFromName(name) {
@@ -36,8 +57,8 @@ class Vertex {
     return Vertex.fromJsonObject(JSON.parse(json));
   }
 
-  static fromJsonObject({ name, weight = DEFAULT_VERTEX_WEIGHT }) {
-    return new Vertex(name, { weight: weight });
+  static fromJsonObject({ name, weight = DEFAULT_VERTEX_WEIGHT, label, data }) {
+    return new Vertex(name, { weight: weight, label: label, data: data });
   }
 
   /**
@@ -52,7 +73,7 @@ class Vertex {
    * @throws {TypeError} if the arguments are not valid, i.e. name is not defined, or weight is not
    *                     (parseable to) a number.
    */
-  constructor(name, { weight = DEFAULT_VERTEX_WEIGHT } = {}) {
+  constructor(name, { label, data, weight = DEFAULT_VERTEX_WEIGHT } = {}) {
     if (!isDefined(name)) {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', name));
     }
@@ -62,10 +83,18 @@ class Vertex {
     if (!isNumber(weight)) {
       throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'weight', weight));
     }
+    if (isDefined(label) && !Vertex.isValidLabel(label)) {
+      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', label));
+    }
+    if (isDefined(data) && !Vertex.isValidData(data)) {
+      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'data', data));
+    }
 
     // Deep clone name
     this.#name = deepClone(name);
     this.#weight = toNumber(weight);
+    this.#label = label;
+    this.#data = data;
   }
 
   get name() {
@@ -76,13 +105,6 @@ class Vertex {
    * HTML-escaped string for name
    */
   get escapedName() {
-    return escape(this.#name.toString());
-  }
-
-  /**
-   * HTML-escaped string from name
-   */
-  get escapedLabel() {
     return escape(this.#name.toString());
   }
 
@@ -101,15 +123,59 @@ class Vertex {
     return this.#weight = toNumber(weight);
   }
 
+  get label() {
+    return this.#label;
+  }
+
+  /**
+   * HTML-escaped string from label
+   */
+  get escapedLabel() {
+    return escape(this.#label);
+  }
+
+  set label(label) {
+    if (isDefined(label) && !Vertex.isValidLabel(label)) {
+      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex.label=', 'label', label));
+    }
+    this.#label = label;
+  }
+
+  get data() {
+    return this.#data;
+  }
+
+  set data(data) {
+    if (isDefined(data) && !Vertex.isValidData(data)) {
+      throw new TypeError(ERROR_MSG_INVALID_ARGUMENT('Vertex.data=', 'data', data));
+    }
+    this.#data = data;
+  }
+
+  hasLabel() {
+    return isDefined(this.#label);
+  }
+
+  hasData() {
+    return isDefined(this.#data);
+  }
+
   toJson() {
     return consistentStringify(this.toJsonObject());
   }
 
   toJsonObject() {
-    return {
+    let json = {
       name: this.name,
       weight: this.weight
     };
+    if (this.hasLabel()) {
+      json['label'] = this.#label;
+    }
+    if (this.hasData()) {
+      json['data'] = this.#data;
+    }
+    return json;
   }
 
   toString() {
@@ -131,7 +197,7 @@ class Vertex {
    *
    */
   clone() {
-    return new Vertex(this.name, { weight: this.weight });
+    return new Vertex(this.name, { weight: this.weight, data: this.data, label: this.label});
   }
 }
 

--- a/test/graph/algo/planarity/kuratowski.test.mjs
+++ b/test/graph/algo/planarity/kuratowski.test.mjs
@@ -69,7 +69,7 @@ describe('Kuratowski\' planarity test', () => {
     for (let j = 0; j < numEdges; j++) {
       let v = randomInt(0, numVertices);
       let u = randomInt(0, numVertices);
-      g.createEdge(Vertex.idFromLabel(u), Vertex.idFromLabel(v), { weight: Math.random() });
+      g.createEdge(Vertex.idFromName(u), Vertex.idFromName(v), { weight: Math.random() });
     }
 
     isPlanar(g).should.be.true();

--- a/test/graph/edge.test.mjs
+++ b/test/graph/edge.test.mjs
@@ -40,7 +40,7 @@ describe('Edge Creation', () => {
         (() => new Edge(undefined)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'source', undefined));
       });
 
-      it('should throw when label is not a Vertex', () => {
+      it('should throw when source is not a Vertex', () => {
         (() => new Edge(1)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'source', 1));
         (() => new Edge('0')).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'source', '0'));
         (() => new Edge(new Set())).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'source', new Set()));
@@ -56,7 +56,7 @@ describe('Edge Creation', () => {
       });
 
 
-      it('should throw when label is not a Vertex', () => {
+      it('should throw when destination is not a Vertex', () => {
         (() => new Edge(v, 11)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'destination', 11));
         (() => new Edge(v, '007')).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'destination', '007'));
         (() => new Edge(v, new Set())).should.throw(ERROR_MSG_INVALID_ARGUMENT('Edge()', 'destination', new Set()));
@@ -128,7 +128,7 @@ describe('Edge Creation', () => {
 });
 
 describe('Attributes', () => {
-  let destinations, sources = destinations = [1, '65.231', 'adbfhs', false, [], { a: 'x' }].map(label => new Vertex(label));
+  let destinations, sources = destinations = [1, '65.231', 'adbfhs', false, [], { a: 'x' }].map(name => new Vertex(name));
 
   describe('source', () => {
     it('# should return the correct value for source', () => {
@@ -204,7 +204,7 @@ describe('Attributes', () => {
 describe('Methods', () => {
   const u = new Vertex({ 1: 'u' });
   const v = new Vertex([false]);
-  const sources = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'].map(label => new Vertex(label));
+  const sources = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'].map(name => new Vertex(name));
   const labels = ['', '1', '-1e14', 'test n° 1', 'unicode ☻'];
   const weights = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'];
 
@@ -241,7 +241,7 @@ describe('Methods', () => {
   });
 
   describe('isLoop()', () => {
-    const sources = [1, '1', 'fdfd', true, [1, 2, 3], { 1: 2 }].map(label => new Vertex(label));
+    const sources = [1, '1', 'fdfd', true, [1, 2, 3], { 1: 2 }].map(name => new Vertex(name));
     it('# should return true if source and destination are the same value (and reference)', () => {
       sources.forEach(s => {
         const e = new Edge(s, s);
@@ -419,8 +419,8 @@ describe('Methods', () => {
       const e = new Edge(new Vertex(0), new Vertex('1', { weight: 2 }), { label: 'label', weight: -0.1e14 });
       JSON.parse(e.toJson()).should.eql(
         {
-          source: { label: 0, weight: 1 },
-          destination: { label: "1", weight: 2 },
+          source: { name: 0, weight: 1 },
+          destination: { name: "1", weight: 2 },
           weight: -10000000000000,
           label: "label"
         });
@@ -432,7 +432,7 @@ describe('Methods', () => {
       const label = "undefined label"
       const weight = 1.1e4;
       const e = new Edge(source, dest, { label: label, weight: weight });
-      e.toJson().should.eql('{"destination":{"label":[1,2,3,[4,5,6]],"weight":1},"label":"undefined label","source":{"label":{"a":1,"b":[{"c":"cLab"},4]},"weight":1},"weight":11000}');
+      e.toJson().should.eql('{"destination":{"name":[1,2,3,[4,5,6]],"weight":1},"label":"undefined label","source":{"name":{"a":1,"b":[{"c":"cLab"},4]},"weight":1},"weight":11000}');
     });
   });
 

--- a/test/graph/edge.test.mjs
+++ b/test/graph/edge.test.mjs
@@ -443,7 +443,7 @@ describe('Methods', () => {
     });
 
     it('# should deep-parse all the fields', () => {
-      const source = new Vertex({ a: 1, b: [{ c: 'cLab' }, 4] });
+      const source = new Vertex({ a: 1, b: [{ c: 'cLab' }, 4] }, {weight: 2, label: 'v label', data: { a: 1, b: [{ c: 'cLab' }, 4] }});
       const dest = new Vertex([1, 2, 3, [4, 5, 6]]);
       const label = "label";
       const weight = 1.1e4;

--- a/test/graph/edge.test.mjs
+++ b/test/graph/edge.test.mjs
@@ -71,7 +71,7 @@ describe('Edge Creation', () => {
 
     describe('# 3rd argument (optional)', () => {
       const u = new Vertex('u');
-      const v = new Vertex(['v']);
+      const v = new Vertex('v');
       it('should default to weight=1', () => {
         new Edge(u, v).weight.should.eql(1);
       });
@@ -98,8 +98,8 @@ describe('Edge Creation', () => {
     });
 
     describe('# 4th argument (optional)', () => {
-      const u = new Vertex({ 1: 'u' });
-      const v = new Vertex([false]);
+      const u = new Vertex(1);
+      const v = new Vertex(2);
 
       it('should default to label=undefined', () => {
         expect(new Edge(u, v).label).to.be.undefined;
@@ -128,7 +128,7 @@ describe('Edge Creation', () => {
 });
 
 describe('Attributes', () => {
-  let destinations, sources = destinations = [1, '65.231', 'adbfhs', false, [], { a: 'x' }].map(name => new Vertex(name));
+  let destinations, sources = destinations = [1, -3.14, '65.231', 'adbfhs', 'test 2'].map(name => new Vertex(name));
 
   describe('source', () => {
     it('# should return the correct value for source', () => {
@@ -202,8 +202,8 @@ describe('Attributes', () => {
 });
 
 describe('Methods', () => {
-  const u = new Vertex({ 1: 'u' });
-  const v = new Vertex([false]);
+  const u = new Vertex('u');
+  const v = new Vertex('v');
   const sources = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'].map(name => new Vertex(name));
   const labels = ['', '1', '-1e14', 'test n° 1', 'unicode ☻'];
   const weights = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'];
@@ -241,7 +241,7 @@ describe('Methods', () => {
   });
 
   describe('isLoop()', () => {
-    const sources = [1, '1', 'fdfd', true, [1, 2, 3], { 1: 2 }].map(name => new Vertex(name));
+    const sources = [1, -5.1, '1', 'fdfd'].map(name => new Vertex(name));
     it('# should return true if source and destination are the same value (and reference)', () => {
       sources.forEach(s => {
         const e = new Edge(s, s);
@@ -254,27 +254,6 @@ describe('Methods', () => {
         const e = new Edge(s, new Vertex('xyz'));
         e.isLoop().should.be.false();
       });
-    });
-
-    it('# should NOT use reference equality', () => {
-      let e = new Edge(new Vertex([1, 4, 65]), new Vertex([1, 4, 65]));
-      e.isLoop().should.be.true();
-      e = new Edge(new Vertex([1, 4, 65]), new Vertex([65, 1, 4]));
-      e.isLoop().should.be.false();
-      e = new Edge(new Vertex({ a: 1 }), new Vertex({ a: 1 }));
-      e.isLoop().should.be.true();
-      e = new Edge(new Vertex({ a: [1, 2, 3] }), new Vertex({ a: [1, 2, 3] }));
-      e.isLoop().should.be.true();
-    });
-
-    it('# should do deep comparison', () => {
-      const s = new Vertex({ a: 3, b: { c: [1, 2, 3], d: [1] } });
-      let d = new Vertex({ a: 3, b: { c: [1, 2, 3], d: [1] } });
-      let e = new Edge(s, d);
-      e.isLoop().should.be.true();
-      d = new Vertex({ a: 3, b: { c: [1, 2, 3, 4], d: [true, false] } });
-      e = new Edge(s, d);
-      e.isLoop().should.be.false();
     });
   });
 
@@ -379,8 +358,8 @@ describe('Methods', () => {
 
     it('# changing the cloned instance should not affect the original', () => {
       const e1 = new Edge(
-        new Vertex([1, 2, { 3: '3' }], { weight: -1 }),
-        new Vertex({ 'a': [true, { false: 3.0 }] }, { weight: 2 }),
+        new Vertex(1, { data: [1] }),
+        new Vertex(2, { weight: 2 }),
         {
           label: choose(labels), weight: Math.random()
         });
@@ -391,11 +370,11 @@ describe('Methods', () => {
       e1.equals(e3).should.be.true();
       e3.equals(e2).should.be.true();
 
-      e2.source.weight = 3.14;
+      e2.source.data.push(2);
       e1.equals(e2).should.be.false();
       e1.equals(e3).should.be.true();
-      e1.source.weight.should.not.eql(e2.source.weight);
-      e1.source.weight.should.eql(e3.source.weight);
+      e1.source.data.should.not.eql(e2.source.data);
+      e1.source.data.should.eql(e3.source.data);
 
       e3.destination.weight = 0.01;
       e1.equals(e3).should.be.false();
@@ -427,12 +406,12 @@ describe('Methods', () => {
     });
 
     it('# should deep-stringify all the fields', () => {
-      const source = new Vertex({ a: 1, b: [{ c: 'cLab' }, 4] });
-      const dest = new Vertex([1, 2, 3, [4, 5, 6]]);
+      const source = new Vertex(0);
+      const dest = new Vertex('[1, 2, 3, [4, 5, 6]]');
       const label = "undefined label"
       const weight = 1.1e4;
       const e = new Edge(source, dest, { label: label, weight: weight });
-      e.toJson().should.eql('{"destination":{"name":[1,2,3,[4,5,6]],"weight":1},"label":"undefined label","source":{"name":{"a":1,"b":[{"c":"cLab"},4]},"weight":1},"weight":11000}');
+      e.toJson().should.eql('{"destination":{"name":"[1, 2, 3, [4, 5, 6]]","weight":1},"label":"undefined label","source":{"name":0,"weight":1},"weight":11000}');
     });
   });
 
@@ -443,8 +422,8 @@ describe('Methods', () => {
     });
 
     it('# should deep-parse all the fields', () => {
-      const source = new Vertex({ a: 1, b: [{ c: 'cLab' }, 4] }, {weight: 2, label: 'v label', data: { a: 1, b: [{ c: 'cLab' }, 4] }});
-      const dest = new Vertex([1, 2, 3, [4, 5, 6]]);
+      const source = new Vertex('s', { weight: 2, label: 'v label', data: { a: 1, b: [{ c: 'cLab' }, 4] } });
+      const dest = new Vertex('[1, 2, 3, [4, 5, 6]]');
       const label = "label";
       const weight = 1.1e4;
       const e = new Edge(source, dest, { label: label, weight: weight });

--- a/test/graph/embedding/embedded_edge.test.mjs
+++ b/test/graph/embedding/embedded_edge.test.mjs
@@ -147,9 +147,9 @@ describe('Attributes', () => {
 
 describe('Methods', () => {
   const point = new Point2D(1, 2);
-  const u = new EmbeddedVertex(['u'], point);
-  const v = new EmbeddedVertex({ name: ['v'] }, point);
-  const w = new EmbeddedVertex(['test', {'test': true}], new Point2D(2.5, 0.12345), { weight: 1.5, vertexRadius: 10 });
+  const u = new EmbeddedVertex('u', point);
+  const v = new EmbeddedVertex('v', point);
+  const w = new EmbeddedVertex('w', new Point2D(2.5, 0.12345), { weight: 1.5, vertexRadius: 10 });
 
   describe('clone()', () => {
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
@@ -175,8 +175,8 @@ describe('Methods', () => {
     it('# should return a valid json', () => {
       const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
       JSON.parse(e.toJson()).should.eql({
-        source: { "name": ["u"], "weight": 1, "position": "[1,2]" },
-        destination: { "name": { "name": ["v"] }, "weight": 1, "position": "[1,2]" },
+        source: { "name": "u", "weight": 1, "position": "[1,2]" },
+        destination: { "name": "v", "weight": 1, "position": "[1,2]" },
         weight: 12,
         arcControlDistance: -32,
         isDirected: true,

--- a/test/graph/embedding/embedded_edge.test.mjs
+++ b/test/graph/embedding/embedded_edge.test.mjs
@@ -175,8 +175,8 @@ describe('Methods', () => {
     it('# should return a valid json', () => {
       const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
       JSON.parse(e.toJson()).should.eql({
-        source: { "label": ["u"], "weight": 1, "position": "[1,2]" },
-        destination: { "label": { "name": ["v"] }, "weight": 1, "position": "[1,2]" },
+        source: { "name": ["u"], "weight": 1, "position": "[1,2]" },
+        destination: { "name": { "name": ["v"] }, "weight": 1, "position": "[1,2]" },
         weight: 12,
         arcControlDistance: -32,
         isDirected: true,

--- a/test/graph/embedding/embedded_vertex.test.mjs
+++ b/test/graph/embedding/embedded_vertex.test.mjs
@@ -34,12 +34,12 @@ describe('EmbeddedVertex Creation', () => {
   describe('# Parameters', () => {
     const point = new Point2D(1, 2);
     describe('# 1st argument (mandatory)', () => {
-      it('should throw when label is null or undefined', () => {
-        (() => new EmbeddedVertex(null, point)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', null));
-        (() => new EmbeddedVertex(undefined, point)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', undefined));
+      it('should throw when name is null or undefined', () => {
+        (() => new EmbeddedVertex(null, point)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', null));
+        (() => new EmbeddedVertex(undefined, point)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', undefined));
       });
 
-      it('should throw when label is not convetible to JSON', () => {
+      it('should throw when name is not convetible to JSON', () => {
         (() => new EmbeddedVertex(new Map(), point)).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Map()));
         (() => new EmbeddedVertex(new Set(), point)).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Set()));
       });
@@ -127,7 +127,7 @@ describe('Methods', () => {
 
     it('# should stringify the fields consistently', () => {
       JSON.parse(v.toJson()).should.eql(
-        { label: 'test', position: '[2,0]', weight: 1.5 }
+        { name: 'test', position: '[2,0]', weight: 1.5 }
       );
     });
   });

--- a/test/graph/embedding/embedded_vertex.test.mjs
+++ b/test/graph/embedding/embedded_vertex.test.mjs
@@ -4,7 +4,7 @@ import Point from '../../../src/geometric/point.mjs';
 import Point2D from '../../../src/geometric/point2d.mjs';
 
 import { testAPI, testStaticAPI } from '../../utils/test_common.mjs';
-import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_LABEL } from '../../../src/common/errors.mjs';
+import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_NAME } from '../../../src/common/errors.mjs';
 
 import 'mjs-mocha';
 import chai from "chai";
@@ -39,17 +39,19 @@ describe('EmbeddedVertex Creation', () => {
         (() => new EmbeddedVertex(undefined, point)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', undefined));
       });
 
-      it('should throw when name is not convetible to JSON', () => {
-        (() => new EmbeddedVertex(new Map(), point)).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Map()));
-        (() => new EmbeddedVertex(new Set(), point)).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Set()));
+      it('should throw when name is not a string or a number', () => {
+        (() => new EmbeddedVertex(false, point)).should.throw(ERROR_MSG_INVALID_NAME('Vertex()', false));
+        (() => new EmbeddedVertex({}, point)).should.throw(ERROR_MSG_INVALID_NAME('Vertex()', {}));
+        (() => new EmbeddedVertex([], point)).should.throw(ERROR_MSG_INVALID_NAME('Vertex()', []));
+        (() => new EmbeddedVertex(new Map(), point)).should.throw(ERROR_MSG_INVALID_NAME('Vertex()', new Map()));
+        (() => new EmbeddedVertex(new Set(), point)).should.throw(ERROR_MSG_INVALID_NAME('Vertex()', new Set()));
       });
 
-      it('should NOT throw with other types', () => {
+      it('should NOT throw with stringa nd numbers', () => {
         (() => new EmbeddedVertex(3, point)).should.not.throw();
+        (() => new EmbeddedVertex(-0.123, point)).should.not.throw();
         (() => new EmbeddedVertex('2', point)).should.not.throw();
-        (() => new EmbeddedVertex([], point)).should.not.throw();
-        (() => new EmbeddedVertex({}, point)).should.not.throw();
-        (() => new EmbeddedVertex(false, point)).should.not.throw();
+        (() => new EmbeddedVertex('test 2', point)).should.not.throw();
       });
     });
 
@@ -71,7 +73,7 @@ describe('EmbeddedVertex Creation', () => {
       });
     });
 
-    describe('# 3rd argument (optional)', () => {
+    describe('# weight (optional)', () => {
       it('should default to weight=1', () => {
         new EmbeddedVertex(2, point).weight.should.eql(1);
       });
@@ -133,7 +135,7 @@ describe('Methods', () => {
   });
 
   describe('fromJson()', () => {
-    const v = new EmbeddedVertex(['test', {'test': true}], new Point2D(2.5, 0.12345), { weight: 1.50 });
+    const v = new EmbeddedVertex('v', new Point2D(2.5, 0.12345), { weight: 1.50 });
     it('# applyed to the result of toJson, it should match source vertex', () => {
       const u = EmbeddedVertex.fromJson(v.toJson());
       u.equals(v).should.be.true();
@@ -143,7 +145,7 @@ describe('Methods', () => {
 
   describe('toSvg()', () => {
     it('# should return a valid svg', () => {
-      let vertex = new EmbeddedVertex("test", new Point2D(10, 10), { weight: 10 });
+      let vertex = new EmbeddedVertex('test', new Point2D(10, 10), { weight: 10 });
       console.log(vertex.toSvg());
     });
   });

--- a/test/graph/embedding/embedding.test.mjs
+++ b/test/graph/embedding/embedding.test.mjs
@@ -227,16 +227,16 @@ describe('Methods', () => {
       let emb = Embedding.forGraph(g);
       [u, v, w].forEach(vertex => {
         const eV = emb.getVertex(vertex.id);
-        eV.label.should.eql(vertex.label);
+        eV.name.should.eql(vertex.name);
         eV.weight.should.eql(vertex.weight);
         eV.position.constructor.should.eql(Point2D);
       });
 
       [e1, e2, e3, e4].forEach(e => {
         const eE = emb.getEdge(e.id);
-        eE.source.label.should.eql(e.source.label);
-        eE.destination.label.should.eql(e.destination.label);
-        (eE.label === e.label).should.be.true();
+        eE.source.name.should.eql(e.source.name);
+        eE.destination.name.should.eql(e.destination.name);
+        (eE.name === e.name).should.be.true();
         eE.weight.should.eql(e.weight);
       });
     });
@@ -247,16 +247,16 @@ describe('Methods', () => {
       let emb = Embedding.forGraph(g, {vertexCoordinates: {[u.id]: p, [w.id]: q}});
       [u, v, w].forEach(vertex => {
         const eV = emb.getVertex(vertex.id);
-        eV.label.should.eql(vertex.label);
+        eV.name.should.eql(vertex.name);
         eV.weight.should.eql(vertex.weight);
         eV.position.constructor.should.eql(Point2D);
       });
 
       [e1, e2, e3, e4].forEach(e => {
         const eE = emb.getEdge(e.id);
-        eE.source.label.should.eql(e.source.label);
-        eE.destination.label.should.eql(e.destination.label);
-        (eE.label === e.label).should.be.true();
+        eE.source.name.should.eql(e.source.name);
+        eE.destination.name.should.eql(e.destination.name);
+        (eE.name === e.name).should.be.true();
         eE.weight.should.eql(e.weight);
       });
 
@@ -271,16 +271,16 @@ describe('Methods', () => {
       let emb = Embedding.forGraph(g, {edgeArcControlDistances: {[e2.id]: -91, [e3.id]: 0.101}});
       [u, v, w].forEach(vertex => {
         const eV = emb.getVertex(vertex.id);
-        eV.label.should.eql(vertex.label);
+        eV.name.should.eql(vertex.name);
         eV.weight.should.eql(vertex.weight);
         eV.position.constructor.should.eql(Point2D);
       });
 
       [e1, e2, e3, e4].forEach(e => {
         const eE = emb.getEdge(e.id);
-        eE.source.label.should.eql(e.source.label);
-        eE.destination.label.should.eql(e.destination.label);
-        (eE.label === e.label).should.be.true();
+        eE.source.name.should.eql(e.source.name);
+        eE.destination.name.should.eql(e.destination.name);
+        (eE.name === e.name).should.be.true();
         eE.weight.should.eql(e.weight);
       });
 
@@ -328,21 +328,21 @@ describe('Methods', () => {
       const vF = graph.createVertex('F', { weight: 2 });
       const vG = graph.createVertex('G', { weight: 2 });
 
-      graph.createEdge(Vertex.idFromLabel('Start'), vA, { label: 'design', weight: 2 });
+      graph.createEdge(Vertex.idFromName('Start'), vA, { label: 'design', weight: 2 });
       graph.createEdge(vA, vB, { label: 'build body' });
       graph.createEdge(vA, vC, { label: 'build wheels' });
       graph.createEdge(vA, vD, { label: 'build frame' });
       graph.createEdge(vA, vE, { label: 'build engine' });
       graph.createEdge(vB, vF, { label: 'paint body' });
       graph.createEdge(vD, vG, { label: 'paint frame' });
-      graph.createEdge(vC, Vertex.idFromLabel('Finish'), { label: 'mount wheels' });
+      graph.createEdge(vC, Vertex.idFromName('Finish'), { label: 'mount wheels' });
       graph.createEdge(vE, vG, { label: 'mount engine on frame' });
-      graph.createEdge(vF, Vertex.idFromLabel('Finish'), { label: 'mount body on frame' });
-      graph.createEdge(vG, Vertex.idFromLabel('Finish'));
+      graph.createEdge(vF, Vertex.idFromName('Finish'), { label: 'mount body on frame' });
+      graph.createEdge(vG, Vertex.idFromName('Finish'));
 
       let emb = Embedding.forGraph(graph);
 
-      emb.setVertexPosition(Vertex.idFromLabel('Start'), new Point2D(50, 200));
+      emb.setVertexPosition(Vertex.idFromName('Start'), new Point2D(50, 200));
       emb.setVertexPosition(vA, new Point2D(200, 200));
       emb.setVertexPosition(vB, new Point2D(350, 50));
       emb.setVertexPosition(vC, new Point2D(350, 150));
@@ -350,7 +350,7 @@ describe('Methods', () => {
       emb.setVertexPosition(vE, new Point2D(350, 350));
       emb.setVertexPosition(vF, new Point2D(500, 100));
       emb.setVertexPosition(vG, new Point2D(600, 300));
-      emb.setVertexPosition(Vertex.idFromLabel('Finish'), new Point2D(650, 200));
+      emb.setVertexPosition(Vertex.idFromName('Finish'), new Point2D(650, 200));
 
       let vClasses = {
         '"Start"': ['start'],

--- a/test/graph/embedding/embedding.test.mjs
+++ b/test/graph/embedding/embedding.test.mjs
@@ -190,7 +190,7 @@ describe('Methods', () => {
 
   describe('fromJson()', () => {
     const point = new Point2D(-0.1, 2.5);
-    const u = new EmbeddedVertex(['u'], point);
+    const u = new EmbeddedVertex(['u'], point, {weight: 4.3, label: 'test v label', data: ['1', 2, 3]});
     const v = new EmbeddedVertex({ name: ['v'] }, point);
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
 

--- a/test/graph/embedding/embedding.test.mjs
+++ b/test/graph/embedding/embedding.test.mjs
@@ -86,14 +86,14 @@ describe('Embedding Creation', () => {
 });
 
 describe('Attributes', () => {
-  const u = new EmbeddedVertex(['u', {true: [false]}], new Point2D(0.1, -0.2));
+  const u = new EmbeddedVertex('u', new Point2D(0.1, -0.2));
   const v = new EmbeddedVertex(1, new Point2D(1, 2));
 
   it('should create an embedding with the right entries in vertices and edges', () => {
     const e1 = new EmbeddedEdge(v, v);
     const e2 = new EmbeddedEdge(u, v);
     let emb = new Embedding([u, v], [e1, e2]);
-    [u,v].forEach(w => [...emb.vertices].some(z => w.equals(z)).should.be.true());
+    [u, v].forEach(w => [...emb.vertices].some(z => w.equals(z)).should.be.true());
     [e1, e2].forEach(e => [...emb.edges].some(e_ => e.equals(e_)).should.be.true());
   });
 });
@@ -102,8 +102,8 @@ describe('Methods', () => {
   describe('setVertexPosition()', () => {
     const p = new Point2D(-0.1, 2.5);
     const q = new Point2D(2.5, 3.14);
-    const u = new EmbeddedVertex(['u'], p);
-    const v = new EmbeddedVertex({ name: ['v', { 'deep': 43.5 }] }, q);
+    const u = new EmbeddedVertex('u', p);
+    const v = new EmbeddedVertex('v', q, { data: { 'deep': 43.5 } });
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
     const emb = new Embedding([u, v], [e]);
 
@@ -117,7 +117,7 @@ describe('Methods', () => {
       (() => emb.setVertexPosition(v, null)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Embedding.setVertexPosition', 'position', null));
       (() => emb.setVertexPosition(v, undefined)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Embedding.setVertexPosition', 'position', undefined));
       (() => emb.setVertexPosition(v, 'not a point')).should.throw(ERROR_MSG_INVALID_ARGUMENT('Embedding.setVertexPosition', 'position', 'not a point'));
-      (() => emb.setVertexPosition(v, new Point(1,2,3))).should.throw(ERROR_MSG_INVALID_ARGUMENT('Embedding.setVertexPosition', 'position', new Point(1,2,3)));
+      (() => emb.setVertexPosition(v, new Point(1, 2, 3))).should.throw(ERROR_MSG_INVALID_ARGUMENT('Embedding.setVertexPosition', 'position', new Point(1, 2, 3)));
     });
 
     it('# should set the new position correctly', () => {
@@ -133,8 +133,8 @@ describe('Methods', () => {
   describe('setEdgeControlPoint()', () => {
     const p = new Point2D(-0.1, 2.5);
     const q = new Point2D(2.5, 3.14);
-    const u = new EmbeddedVertex(['u'], p);
-    const v = new EmbeddedVertex({ name: ['v', { 'deep': 43.5 }] }, q);
+    const u = new EmbeddedVertex('u', p);
+    const v = new EmbeddedVertex('v', q);
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
     const emb = new Embedding([u, v], [e]);
 
@@ -161,8 +161,8 @@ describe('Methods', () => {
 
   describe('clone()', () => {
     const point = new Point2D(-0.1, 2.5);
-    const u = new EmbeddedVertex(['u'], point);
-    const v = new EmbeddedVertex({ name: ['v', { 'deep': 43.5 }] }, point);
+    const u = new EmbeddedVertex('u', point);
+    const v = new EmbeddedVertex('v', point);
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
 
     it('# should make an exact copy', () => {
@@ -175,8 +175,8 @@ describe('Methods', () => {
 
   describe('toJson()', () => {
     const point = new Point2D(-0.1, 2.5);
-    const u = new EmbeddedVertex(['u'], point);
-    const v = new EmbeddedVertex({ name: ['v'] }, point);
+    const u = new EmbeddedVertex('u', point);
+    const v = new EmbeddedVertex('v', point);
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
 
     it('# should return a valid json', () => {
@@ -190,8 +190,8 @@ describe('Methods', () => {
 
   describe('fromJson()', () => {
     const point = new Point2D(-0.1, 2.5);
-    const u = new EmbeddedVertex(['u'], point, {weight: 4.3, label: 'test v label', data: ['1', 2, 3]});
-    const v = new EmbeddedVertex({ name: ['v'] }, point);
+    const u = new EmbeddedVertex('u', point, { weight: 4.3, label: 'test v label', data: ['1', 2, 3] });
+    const v = new EmbeddedVertex('v', point);
     const e = new EmbeddedEdge(u, v, { weight: 12, label: 'edge', arcControlDistance: -32, isDirected: true });
 
     it('# applyed to the result of toJson, it should match source vertex', () => {
@@ -207,8 +207,8 @@ describe('Methods', () => {
   });
 
   describe('forGraph()', () => {
-    const u = new Vertex(['u']);
-    const v = new Vertex({ name: ['v'] });
+    const u = new Vertex('u');
+    const v = new Vertex('v');
     const w = new Vertex('w');
     const e1 = new Edge(u, v, { weight: 12, label: 'edge' });
     const e2 = new Edge(w, v);
@@ -242,9 +242,9 @@ describe('Methods', () => {
     });
 
     it('# should allow passing coordinates for some or all vertices', () => {
-      const p = new Point2D(1,2);
-      const q = new Point2D(2,1);
-      let emb = Embedding.forGraph(g, {vertexCoordinates: {[u.id]: p, [w.id]: q}});
+      const p = new Point2D(1, 2);
+      const q = new Point2D(2, 1);
+      let emb = Embedding.forGraph(g, { vertexCoordinates: { [u.id]: p, [w.id]: q } });
       [u, v, w].forEach(vertex => {
         const eV = emb.getVertex(vertex.id);
         eV.name.should.eql(vertex.name);
@@ -268,7 +268,7 @@ describe('Methods', () => {
     });
 
     it('# should allow passing arc\'s control point for some or all edges', () => {
-      let emb = Embedding.forGraph(g, {edgeArcControlDistances: {[e2.id]: -91, [e3.id]: 0.101}});
+      let emb = Embedding.forGraph(g, { edgeArcControlDistances: { [e2.id]: -91, [e3.id]: 0.101 } });
       [u, v, w].forEach(vertex => {
         const eV = emb.getVertex(vertex.id);
         eV.name.should.eql(vertex.name);

--- a/test/graph/graph.test.mjs
+++ b/test/graph/graph.test.mjs
@@ -7,7 +7,7 @@ import DfsResult from '../../src/graph/algo/dfs.mjs';
 
 import { choose } from '../../src/common/array.mjs';
 import { randomInt } from '../../src/common/numbers.mjs';
-import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_VERTEX_DUPLICATED, ERROR_MSG_VERTEX_NOT_FOUND, ERROR_MSG_EDGE_NOT_FOUND } from '../../src/common/errors.mjs'
+import { ERROR_MSG_INVALID_ARGUMENT, ERROR_MSG_INVALID_DATA, ERROR_MSG_INVALID_LABEL, ERROR_MSG_VERTEX_DUPLICATED, ERROR_MSG_VERTEX_NOT_FOUND, ERROR_MSG_EDGE_NOT_FOUND } from '../../src/common/errors.mjs'
 
 import { range } from '../../src/common/numbers.mjs';
 import { isObject } from '../../src/common/basic.mjs';
@@ -74,7 +74,8 @@ describe('Graph API', () => {
   it('# Object\'s interface should be complete', () => {
     let edge = new Graph();
     let methods = ['constructor', 'equals', 'clone', 'isDirected', 'isEmpty', 'toString', 'toJson', 'toJsonObject',
-      'createVertex', 'addVertex', 'hasVertex', 'getVertex', 'getVertexWeight', 'getVertexOutDegree', 'setVertexWeight',
+      'createVertex', 'addVertex', 'hasVertex', 'getVertex', 'getVertexOutDegree', 'getVertexWeight', 'setVertexWeight',
+      'getVertexLabel', 'setVertexLabel', 'getVertexData', 'setVertexData',
       'createEdge', 'addEdge', 'hasEdge', 'hasEdgeBetween', 'getEdge', 'getEdgeBetween', 'getEdgesFrom', 'getEdgesInPath',
       'getEdgeLabel', 'getEdgeWeight', 'setEdgeWeight',
       'isAcyclic', 'isConnected', 'isStronglyConnected', 'isBipartite', 'isComplete', 'isCompleteBipartite',
@@ -203,9 +204,129 @@ describe('getVertexWeight', () => {
     g.getVertexWeight(Vertex.idFromName('{ what: -3 }')).should.eql(1);
   });
 
-  it('# Should return undefined when the graph does not have a vertex', () => {
-    expect(g.getVertexWeight('not here')).to.be.undefined;
-    expect(g.getVertexWeight(2)).to.be.undefined;
+  it('# Should throw when the graph does not have a vertex', () => {
+    (() => g.getVertexWeight('not here')).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexWeight', 'not here'));
+    (() => g.getVertexWeight(2)).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexWeight', 2));
+  });
+});
+
+describe('setVertexWeight', () => {
+  let g;
+
+  beforeEach(() => {
+    g = createExampleGraph();
+  });
+
+  it('# Should set weight correctly', () => {
+    const vId = Vertex.idFromName(1);
+    g.getVertexWeight(vId).should.eql(-21);
+    g.setVertexWeight(vId, 0);
+    g.getVertexWeight(vId).should.eql(0);
+    g.setVertexWeight(vId, 2.51);
+    g.getVertexWeight(vId).should.eql(2.51);
+  });
+
+  it('# Should throw when the value is not valid', () => {
+    const vId = Vertex.idFromName(1);
+    (() => g.setVertexWeight(vId)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setVertexWeight', 'weight', undefined));
+    (() => g.setVertexWeight(vId, null)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setVertexWeight', 'weight', null));
+    (() => g.setVertexWeight(vId, 'test')).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setVertexWeight', 'weight', 'test'));
+  });
+
+  it('# Should throw when the vertex is not in the graph', () => {
+    (() => g.setVertexWeight('not here', 10)).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.setVertexWeight', 'not here'));
+  });
+});
+
+describe('getVertexLabel', () => {
+  const g = createExampleGraph();
+
+  it('# Should retrieve the right weight', () => {
+    g.getVertexLabel(Vertex.idFromName('{ what: -3 }')).should.eql('test');
+  });
+
+  it('# Should throw when the graph does not have a vertex', () => {
+    (() => g.getVertexLabel('not here')).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexLabel', 'not here'));
+    (() => g.getVertexLabel(2)).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexLabel', 2));
+  });
+});
+
+describe('setVertexLabel', () => {
+  let g;
+
+  beforeEach(() => {
+    g = createExampleGraph();
+  });
+
+  it('# Should set label correctly', () => {
+    const vId = Vertex.idFromName('{ what: -3 }');
+    g.getVertexLabel(vId).should.eql('test');
+    g.setVertexLabel(vId, 'new test');
+    g.getVertexLabel(vId).should.eql('new test');
+    g.setVertexLabel(vId, 'unicode is fine ♥');
+    g.getVertexLabel(vId).should.eql('unicode is fine ♥');
+  });
+
+  it('# Should allow to set label to null, undefined or the empty string', () => {
+    const vId = Vertex.idFromName('{ what: -3 }');
+    (() => g.setVertexLabel(vId)).should.not.throw();
+    (() => g.setVertexLabel(vId, null)).should.not.throw();
+    (() => g.setVertexLabel(vId, '')).should.not.throw();
+  });
+
+  it('# Should throw when the label is not valid', () => {
+    const vId = Vertex.idFromName(1);
+    (() => g.setVertexLabel(vId, 1.1)).should.throw(ERROR_MSG_INVALID_LABEL('Graph.setVertexLabel', 1.1));
+  });
+
+  it('# Should throw when the vertex is not in the graph', () => {
+    (() => g.setVertexLabel('not here', '10')).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.setVertexLabel', 'not here'));
+  });
+});
+
+describe('getVertexData', () => {
+  const g = createExampleGraph();
+
+  it('# Should retrieve the right data', () => {
+    g.getVertexData(Vertex.idFromName('{ what: -3 }')).should.eql([1, true, -3]);
+  });
+
+  it('# Should throw when the graph does not have a vertex', () => {
+    (() => g.getVertexData('not here')).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexData', 'not here'));
+    (() => g.getVertexData(2)).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.getVertexData', 2));
+  });
+});
+
+describe('setVertexData', () => {
+  let g;
+
+  beforeEach(() => {
+    g = createExampleGraph();
+  });
+
+  it('# Should set data correctly', () => {
+    const vId = Vertex.idFromName('{ what: -3 }');
+    g.getVertexData(vId).should.eql([1, true, -3]);
+    g.setVertexData(vId, 'new test');
+    g.getVertexData(vId).should.eql('new test');
+    g.setVertexData(vId, { test: 1, prova: [1, 2, 3] });
+    g.getVertexData(vId).should.eql({ test: 1, prova: [1, 2, 3] });
+  });
+
+  it('# Should allow to set data to null or undefined', () => {
+    const vId = Vertex.idFromName('{ what: -3 }');
+    (() => g.setVertexData(vId)).should.not.throw();
+    (() => g.setVertexData(vId, null)).should.not.throw();
+  });
+
+  it('# Should throw when the data is not valid', () => {
+    const vId = Vertex.idFromName(1);
+    (() => g.setVertexData(vId, new Map())).should.throw(ERROR_MSG_INVALID_DATA('Graph.setVertexData', new Map()));
+    (() => g.setVertexData(vId, new Set())).should.throw(ERROR_MSG_INVALID_DATA('Graph.setVertexData', new Set()));
+  });
+
+  it('# Should throw when the vertex is not in the graph', () => {
+    (() => g.setVertexData('not here', 10)).should.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.setVertexData', 'not here'));
   });
 });
 
@@ -300,27 +421,6 @@ describe('getEdgeLabel', () => {
   });
 });
 
-describe('getEdgeWeight', () => {
-  const g = createExampleGraph();
-
-  it('# Should retrieve the right weight', () => {
-    g.getEdgeWeight(Vertex.idFromName('a random unicòde string ☺'), Vertex.idFromName(1)).should.eql(-0.1e14);
-    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.eql(33);
-
-  });
-
-  it('# Should default to 1 (when edge weight is not set explicitly)', () => {
-    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.be.true();
-    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.eql(1);
-  });
-
-  it('# Should return undefined when edge does not exist', () => {
-    expect(g.getEdgeWeight(1, 'a random unicòde string ☺')).to.be.undefined;
-    expect(g.getEdgeWeight('not in graph', 1)).to.be.undefined;
-    expect(g.getEdgeWeight(3, 2)).to.be.undefined;
-  });
-});
-
 describe('getEdgesInPath()', () => {
   let g = new Graph();
 
@@ -380,6 +480,48 @@ describe('getEdgesInPath()', () => {
     path.every(e => e instanceof Edge).should.be.true();
     path[0].source.id.should.eql('"6"');
     path[0].destination.id.should.eql('"7"');
+  });
+});
+
+describe('getEdgeWeight', () => {
+  const g = createExampleGraph();
+
+  it('# Should retrieve the right weight', () => {
+    g.getEdgeWeight(Vertex.idFromName('a random unicòde string ☺'), Vertex.idFromName(1)).should.eql(-0.1e14);
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.eql(33);
+  });
+
+  it('# Should default to 1 (when edge weight is not set explicitly)', () => {
+    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.be.true();
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.eql(1);
+  });
+
+  it('# Should throw when edge does not exist', () => {
+    (() => g.getEdgeWeight(1, 'a random unicòde string ☺')).should.throw(ERROR_MSG_EDGE_NOT_FOUND('Graph.getEdgeWeight', `${1} -> ${'a random unicòde string ☺'}`));
+    (() => g.getEdgeWeight('not in graph', 1)).should.throw(ERROR_MSG_EDGE_NOT_FOUND('Graph.getEdgeWeight', `${'not in graph'} -> ${1}`));
+    (() => g.getEdgeWeight(3, 2)).should.throw(ERROR_MSG_EDGE_NOT_FOUND('Graph.getEdgeWeight', `${3} -> ${2}`));
+  });
+});
+
+describe('setEdgeWeight', () => {
+  const g = createExampleGraph();
+
+  it('# Should set the right weight', () => {
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.eql(33);
+    g.setEdgeWeight(g.getEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')), 0);
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.eql(0);
+  });
+
+  it('# Should throw when an invalid value is passed', () => {
+    const e = g.getEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }'));
+    (() => g.setEdgeWeight(e)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setEdgeWeight', 'weight', undefined));
+    (() => g.setEdgeWeight(e, null)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setEdgeWeight', 'weight', null));
+    (() => g.setEdgeWeight(e, 'a')).should.throw(ERROR_MSG_INVALID_ARGUMENT('Graph.setEdgeWeight', 'weight', 'a'));
+  });
+
+  it('# Should throw when the edge is not in the graph', () => {
+    const e = new Edge(new Vertex(-3.1415), new Vertex('any vertex not in the graph'));
+    (() => g.setEdgeWeight(e, 1)).should.throw(ERROR_MSG_EDGE_NOT_FOUND('Graph.setEdgeWeight', e));
   });
 });
 
@@ -509,7 +651,7 @@ describe('fromJson()', () => {
 
   it('# applyed to the result of toJson, it should match source graph ', () => {
     const g1 = Graph.fromJson(g.toJson());
-
+    g1.toJson().should.eql(g.toJson())
     g1.equals(g).should.be.true();
     g1.hasVertex(v2).should.be.true();
     g1.hasVertex(v4).should.be.true();

--- a/test/graph/graph.test.mjs
+++ b/test/graph/graph.test.mjs
@@ -487,7 +487,7 @@ describe('fromJsonObject()', () => {
   const v1 = g.createVertex('abc');
   const v2 = g.createVertex(1);
   const v3 = g.createVertex(3.1415);
-  const v4 = g.createVertex({ 'what': -3 });
+  const v4 = g.createVertex({ 'what': -3 }, {weight: 3, label: 'v', data: { 'what': -3 }});
 
   g.createEdge(v1, v2, { label: 'label', weight: -0.1e14 });
   g.createEdge(v3, v4, { weight: 33 });

--- a/test/graph/graph.test.mjs
+++ b/test/graph/graph.test.mjs
@@ -46,7 +46,7 @@ function createRandomGraph(g, minV, maxV, minE, maxE) {
   for (let j = 0; j < numEdges; j++) {
     let v = randomInt(0, numVertices);
     let u = randomInt(0, numVertices);
-    g.createEdge(Vertex.idFromLabel(u), Vertex.idFromLabel(v), { weight: Math.random() });
+    g.createEdge(Vertex.idFromName(u), Vertex.idFromName(v), { weight: Math.random() });
   }
   return g;
 }
@@ -66,7 +66,7 @@ describe('Graph API', () => {
     Graph.should.be.a.constructor();
   });
 
-  it('# should have static methods availabel', () => {
+  it('# should have static methods available', () => {
     let staticMethods = ['fromJson', 'fromJsonObject', 'completeGraph', 'completeBipartiteGraph'];
     testStaticAPI(Graph, staticMethods);
   });
@@ -144,33 +144,33 @@ describe('id', () => {
 });
 
 describe('createVertex()', () => {
-  const labels = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
-  it('# should add all valid label types', () => {
+  const names = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
+  it('# should add all valid name types', () => {
     let g = new Graph();
-    labels.forEach(label => {
-      g.createVertex(label, { weight: Math.random() });
+    names.forEach(name => {
+      g.createVertex(name, { weight: Math.random() });
     });
 
-    labels.forEach(label => {
-      g.hasVertex(Vertex.idFromLabel(label)).should.be.true();
+    names.forEach(name => {
+      g.hasVertex(Vertex.idFromName(name)).should.be.true();
     });
   });
 
   it('# should throw on duplicates', () => {
     let g = new Graph();
-    labels.forEach(label => {
-      g.createVertex(label, { weight: Math.random() });
+    names.forEach(name => {
+      g.createVertex(name, { weight: Math.random() });
     });
-    // Try to add each label once more
-    labels.forEach(label => {
-      expect(() => g.createVertex(label, { weight: Math.random() })).to.throw(ERROR_MSG_VERTEX_DUPLICATED('Graph.createVertex', label));
+    // Try to add each name once more
+    names.forEach(name => {
+      expect(() => g.createVertex(name, { weight: Math.random() })).to.throw(ERROR_MSG_VERTEX_DUPLICATED('Graph.createVertex', name));
     });
   });
 });
 
 describe('addVertex()', () => {
   const vertices = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }].map(v => new Vertex(v));
-  it('# should add all valid label types', () => {
+  it('# should add all valid name types', () => {
     let g = new Graph();
     vertices.forEach(v => {
       g.addVertex(v);
@@ -186,7 +186,7 @@ describe('addVertex()', () => {
     vertices.forEach(v => {
       g.addVertex(v);
     });
-    // Try to add each label once more
+    // Try to add each name once more
     vertices.forEach(v => {
       expect(() => g.addVertex(v)).to.throw(ERROR_MSG_VERTEX_DUPLICATED('Graph.addVertex', v));
     });
@@ -197,10 +197,10 @@ describe('getVertexWeight', () => {
   const g = createExampleGraph();
 
   it('# Should retrieve the right weight', () => {
-    g.getVertexWeight(Vertex.idFromLabel(1)).should.eql(-21);
+    g.getVertexWeight(Vertex.idFromName(1)).should.eql(-21);
     // defaults to 1 when not explicitly set
-    g.getVertexWeight(Vertex.idFromLabel('a random unicòde string ☺')).should.eql(1);
-    g.getVertexWeight(Vertex.idFromLabel({ 'what': -3 })).should.eql(1);
+    g.getVertexWeight(Vertex.idFromName('a random unicòde string ☺')).should.eql(1);
+    g.getVertexWeight(Vertex.idFromName({ 'what': -3 })).should.eql(1);
   });
 
   it('# Should return undefined when the graph does not have a vertex', () => {
@@ -210,30 +210,30 @@ describe('getVertexWeight', () => {
 });
 
 describe('createEdge()', () => {
-  const labels = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
-  const ids = labels.map(Vertex.idFromLabel);
+  const names = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
+  const ids = names.map(Vertex.idFromName);
 
-  it('# should add all valid label types', () => {
+  it('# should add all valid name types', () => {
     let g = new Graph();
-    labels.forEach(label => {
-      g.createVertex(label, { weight: Math.random() });
+    names.forEach(name => {
+      g.createVertex(name, { weight: Math.random() });
     });
 
     g.createEdge(ids[1], ids[5]);
     let e = g.getEdgeBetween(ids[1], ids[5]);
-    e.source.label.should.eql(labels[1]);
-    e.destination.label.should.eql(labels[5]);
+    e.source.name.should.eql(names[1]);
+    e.destination.name.should.eql(names[5]);
     g.hasEdge(e).should.be.true();
 
     e = g.getEdge(g.createEdge(ids[0], ids[6], { weight: 5, label: 'edge label' }));
 
-    e.source.label.should.eql(labels[0]);
-    e.destination.label.should.eql(labels[6]);
+    e.source.name.should.eql(names[0]);
+    e.destination.name.should.eql(names[6]);
     e.weight.should.eql(5);
     e.label.should.eql('edge label');
     g.hasEdge(e).should.be.true();
 
-    e = new Edge(new Vertex(labels[0]), new Vertex(labels[2]));
+    e = new Edge(new Vertex(names[0]), new Vertex(names[2]));
     g.hasEdge(e).should.be.false();
 
     g.hasEdgeBetween(ids[0], ids[6]).should.be.true();
@@ -246,8 +246,8 @@ describe('createEdge()', () => {
 
   it('# should throw when vertices are not in the graph', () => {
     let g = new Graph();
-    labels.forEach(label => {
-      g.createVertex(label, { weight: Math.random() });
+    names.forEach(name => {
+      g.createVertex(name, { weight: Math.random() });
     });
     expect(() => g.createEdge('v', ids[0])).to.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.createEdge', 'v'));
     expect(() => g.createEdge(ids[0], 'u')).to.throw(ERROR_MSG_VERTEX_NOT_FOUND('Graph.createEdge', 'u'));
@@ -256,7 +256,7 @@ describe('createEdge()', () => {
 
 describe('addEdge()', () => {
   const sources = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }].map(lab => new Vertex(lab));
-  it('# should add all valid label types', () => {
+  it('# should add all valid name types', () => {
     let g = new Graph();
     sources.forEach(v => {
       g.addVertex(v, { weight: Math.random() });
@@ -285,12 +285,12 @@ describe('getEdgeLabel', () => {
   const g = createExampleGraph();
 
   it('# Should retrieve the right label', () => {
-    g.getEdgeLabel(Vertex.idFromLabel('a random unicòde string ☺'), Vertex.idFromLabel(1)).should.eql('label');
+    g.getEdgeLabel(Vertex.idFromName('a random unicòde string ☺'), Vertex.idFromName(1)).should.eql('label');
   });
 
   it('# Should return undefined when edge does not have a label', () => {
-    g.hasEdgeBetween(Vertex.idFromLabel(-3.1415), Vertex.idFromLabel({ 'what': -3 })).should.be.true();
-    expect(g.getEdgeLabel(Vertex.idFromLabel(-3.1415), Vertex.idFromLabel({ 'what': -3 }))).to.be.undefined;
+    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 })).should.be.true();
+    expect(g.getEdgeLabel(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 }))).to.be.undefined;
   });
 
   it('# Should return undefined when edge does not exist', () => {
@@ -304,14 +304,14 @@ describe('getEdgeWeight', () => {
   const g = createExampleGraph();
 
   it('# Should retrieve the right weight', () => {
-    g.getEdgeWeight(Vertex.idFromLabel('a random unicòde string ☺'), Vertex.idFromLabel(1)).should.eql(-0.1e14);
-    g.getEdgeWeight(Vertex.idFromLabel(-3.1415), Vertex.idFromLabel({ 'what': -3 })).should.eql(33);
+    g.getEdgeWeight(Vertex.idFromName('a random unicòde string ☺'), Vertex.idFromName(1)).should.eql(-0.1e14);
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 })).should.eql(33);
 
   });
 
   it('# Should default to 1 (when edge weight is not set explicitly)', () => {
-    g.hasEdgeBetween(Vertex.idFromLabel(-3.1415), Vertex.idFromLabel([1, true, -3])).should.be.true();
-    g.getEdgeWeight(Vertex.idFromLabel(-3.1415), Vertex.idFromLabel([1, true, -3])).should.eql(1);
+    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName([1, true, -3])).should.be.true();
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName([1, true, -3])).should.eql(1);
   });
 
   it('# Should return undefined when edge does not exist', () => {
@@ -414,7 +414,7 @@ describe('equals()', () => {
 });
 
 describe('toJson()', () => {
-  const sources = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'].map(label => new Vertex(label));
+  const sources = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'].map(name => new Vertex(name));
   const labels = ['', '1', '-1e14', 'test n° 1', 'unicode ☻'];
   it('# should return a valid json', () => {
     sources.forEach(source => {
@@ -423,8 +423,8 @@ describe('toJson()', () => {
       const edgeLabel = choose(labels);
       const weight = Math.random();
       let e = new Edge(source, dest, { label: edgeLabel, weight: weight });
-      let u = new Vertex(source.label, { weight: Math.random(), outgoingEdges: [e] });
-      let v = new Vertex(dest.label, { weight: Math.random() });
+      let u = new Vertex(source.name, { weight: Math.random(), outgoingEdges: [e] });
+      let v = new Vertex(dest.name, { weight: Math.random() });
       g.addVertex(u);
       if (v.id != u.id) {
         g.addVertex(v);
@@ -448,10 +448,10 @@ describe('toJson()', () => {
     expect(() => JSON.parse(g.toJson())).not.to.throw();
     JSON.parse(g.toJson()).should.eql(
       {
-        vertices: [{ label: "abc", weight: 1 }, { label: 1, weight: 1 }, { label: 3.1415, weight: 1 }, { label: { what: -3 }, weight: 1 }],
+        vertices: [{ name: "abc", weight: 1 }, { name: 1, weight: 1 }, { name: 3.1415, weight: 1 }, { name: { what: -3 }, weight: 1 }],
         edges: [
-          { source: { label: "abc", weight: 1 }, destination: { label: 1, weight: 1 }, label: "label", weight: -10000000000000 },
-          { source: { label: 3.1415, weight: 1 }, destination: { label: { what: -3 }, weight: 1 }, weight: 33 }]
+          { source: { name: "abc", weight: 1 }, destination: { name: 1, weight: 1 }, label: "label", weight: -10000000000000 },
+          { source: { name: 3.1415, weight: 1 }, destination: { name: { what: -3 }, weight: 1 }, weight: 33 }]
       });
   });
 });
@@ -465,20 +465,20 @@ describe('clone()', () => {
   it('# modifying deep clones should not affect originals', () => {
     let g = new Graph();
 
-    let label1 = { 'what': -3 };
-    let label2 = [1, true, -3];
-    let v1 = g.createVertex(label1);
-    let v2 = g.createVertex(label2);
+    let name1 = { 'what': -3 };
+    let name2 = [1, true, -3];
+    let v1 = g.createVertex(name1);
+    let v2 = g.createVertex(name2);
 
     g.createEdge(v1, v2);
     let g1 = g.clone();
 
-    label1['new'] = true;
+    name1['new'] = true;
 
-    g.hasVertex(Vertex.idFromLabel(label1)).should.be.false();
-    g1.hasVertex(Vertex.idFromLabel(label1)).should.be.false();
-    g.hasVertex(Vertex.idFromLabel({ 'what': -3 })).should.be.true();
-    g1.hasVertex(Vertex.idFromLabel({ 'what': -3 })).should.be.true();
+    g.hasVertex(Vertex.idFromName(name1)).should.be.false();
+    g1.hasVertex(Vertex.idFromName(name1)).should.be.false();
+    g.hasVertex(Vertex.idFromName({ 'what': -3 })).should.be.true();
+    g1.hasVertex(Vertex.idFromName({ 'what': -3 })).should.be.true();
   });
 });
 

--- a/test/graph/graph.test.mjs
+++ b/test/graph/graph.test.mjs
@@ -26,8 +26,8 @@ function createExampleGraph() {
   const v1 = g.createVertex('a random unicòde string ☺');
   const v2 = g.createVertex(1, { weight: -21 });
   const v3 = g.createVertex(-3.1415);
-  const v4 = g.createVertex({ 'what': -3 });
-  const v5 = g.createVertex([1, true, -3]);
+  const v4 = g.createVertex('{ what: -3 }', { label: 'test', data: [1, true, -3] });
+  const v5 = g.createVertex('[1, true, -3]');
 
   g.createEdge(g.getVertex(v1), g.getVertex(v2), { label: 'label', weight: -0.1e14 });
   g.createEdge(g.getVertex(v3), g.getVertex(v4), { weight: 33 });
@@ -144,7 +144,7 @@ describe('id', () => {
 });
 
 describe('createVertex()', () => {
-  const names = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
+  const names = [1, -0.000001, '65.231', 'adbfhs'];
   it('# should add all valid name types', () => {
     let g = new Graph();
     names.forEach(name => {
@@ -169,7 +169,7 @@ describe('createVertex()', () => {
 });
 
 describe('addVertex()', () => {
-  const vertices = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }].map(v => new Vertex(v));
+  const vertices = [1, -2.3, '65.231', 'adbfhs', 'false, [], { a: 1 }'].map(v => new Vertex(v));
   it('# should add all valid name types', () => {
     let g = new Graph();
     vertices.forEach(v => {
@@ -200,7 +200,7 @@ describe('getVertexWeight', () => {
     g.getVertexWeight(Vertex.idFromName(1)).should.eql(-21);
     // defaults to 1 when not explicitly set
     g.getVertexWeight(Vertex.idFromName('a random unicòde string ☺')).should.eql(1);
-    g.getVertexWeight(Vertex.idFromName({ 'what': -3 })).should.eql(1);
+    g.getVertexWeight(Vertex.idFromName('{ what: -3 }')).should.eql(1);
   });
 
   it('# Should return undefined when the graph does not have a vertex', () => {
@@ -210,7 +210,7 @@ describe('getVertexWeight', () => {
 });
 
 describe('createEdge()', () => {
-  const names = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }];
+  const names = [1, 2.12, -5, '65.231', 'adbfhs', 'false, [], { a: x }', '{ a: [true, { false: 3.0 }] }'];
   const ids = names.map(Vertex.idFromName);
 
   it('# should add all valid name types', () => {
@@ -255,7 +255,7 @@ describe('createEdge()', () => {
 });
 
 describe('addEdge()', () => {
-  const sources = [1, '65.231', 'adbfhs', false, [], { a: 'x' }, { 'a': [true, { false: 3.0 }] }].map(lab => new Vertex(lab));
+  const sources = [1, '65.231', 'adbfhs', 'false, [], { a: x }', '{ a: [true, { false: 3.0 }] }'].map(lab => new Vertex(lab));
   it('# should add all valid name types', () => {
     let g = new Graph();
     sources.forEach(v => {
@@ -289,8 +289,8 @@ describe('getEdgeLabel', () => {
   });
 
   it('# Should return undefined when edge does not have a label', () => {
-    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 })).should.be.true();
-    expect(g.getEdgeLabel(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 }))).to.be.undefined;
+    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.be.true();
+    expect(g.getEdgeLabel(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }'))).to.be.undefined;
   });
 
   it('# Should return undefined when edge does not exist', () => {
@@ -305,13 +305,13 @@ describe('getEdgeWeight', () => {
 
   it('# Should retrieve the right weight', () => {
     g.getEdgeWeight(Vertex.idFromName('a random unicòde string ☺'), Vertex.idFromName(1)).should.eql(-0.1e14);
-    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName({ 'what': -3 })).should.eql(33);
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('{ what: -3 }')).should.eql(33);
 
   });
 
   it('# Should default to 1 (when edge weight is not set explicitly)', () => {
-    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName([1, true, -3])).should.be.true();
-    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName([1, true, -3])).should.eql(1);
+    g.hasEdgeBetween(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.be.true();
+    g.getEdgeWeight(Vertex.idFromName(-3.1415), Vertex.idFromName('[1, true, -3]')).should.eql(1);
   });
 
   it('# Should return undefined when edge does not exist', () => {
@@ -440,7 +440,7 @@ describe('toJson()', () => {
     let v1 = g.createVertex('abc');
     let v2 = g.createVertex(1);
     let v3 = g.createVertex(3.1415);
-    let v4 = g.createVertex({ 'what': -3 });
+    let v4 = g.createVertex('{ "what": -3 }');
 
     g.createEdge(v1, v2, { label: 'label', weight: -0.1e14 });
     g.createEdge(v3, v4, { weight: 33 });
@@ -448,10 +448,10 @@ describe('toJson()', () => {
     expect(() => JSON.parse(g.toJson())).not.to.throw();
     JSON.parse(g.toJson()).should.eql(
       {
-        vertices: [{ name: "abc", weight: 1 }, { name: 1, weight: 1 }, { name: 3.1415, weight: 1 }, { name: { what: -3 }, weight: 1 }],
+        vertices: [{ name: "abc", weight: 1 }, { name: '{ "what": -3 }', weight: 1 }, { name: 1, weight: 1 }, { name: 3.1415, weight: 1 }],
         edges: [
           { source: { name: "abc", weight: 1 }, destination: { name: 1, weight: 1 }, label: "label", weight: -10000000000000 },
-          { source: { name: 3.1415, weight: 1 }, destination: { name: { what: -3 }, weight: 1 }, weight: 33 }]
+          { source: { name: 3.1415, weight: 1 }, destination: { name: '{ "what": -3 }', weight: 1 }, weight: 33 }]
       });
   });
 });
@@ -465,20 +465,18 @@ describe('clone()', () => {
   it('# modifying deep clones should not affect originals', () => {
     let g = new Graph();
 
-    let name1 = { 'what': -3 };
-    let name2 = [1, true, -3];
+    let name1 = 1;
+    let name2 = 2.12;
     let v1 = g.createVertex(name1);
     let v2 = g.createVertex(name2);
 
     g.createEdge(v1, v2);
     let g1 = g.clone();
 
-    name1['new'] = true;
+    g.getVertex(v1).data = [];
 
-    g.hasVertex(Vertex.idFromName(name1)).should.be.false();
-    g1.hasVertex(Vertex.idFromName(name1)).should.be.false();
-    g.hasVertex(Vertex.idFromName({ 'what': -3 })).should.be.true();
-    g1.hasVertex(Vertex.idFromName({ 'what': -3 })).should.be.true();
+    expect(g1.getVertex(v1).data).to.be.undefined;
+    g1.equals(g).should.be.false();
   });
 });
 
@@ -487,7 +485,7 @@ describe('fromJsonObject()', () => {
   const v1 = g.createVertex('abc');
   const v2 = g.createVertex(1);
   const v3 = g.createVertex(3.1415);
-  const v4 = g.createVertex({ 'what': -3 }, {weight: 3, label: 'v', data: { 'what': -3 }});
+  const v4 = g.createVertex('{ what: -3 }', { weight: 3, label: 'v', data: { 'what': -3 } });
 
   g.createEdge(v1, v2, { label: 'label', weight: -0.1e14 });
   g.createEdge(v3, v4, { weight: 33 });
@@ -501,9 +499,9 @@ describe('fromJsonObject()', () => {
 describe('fromJson()', () => {
   const g = new Graph();
   const v1 = g.createVertex('abc');
-  const v2 = g.createVertex({ 'a': [true, { false: 3.0 }] });
+  const v2 = g.createVertex('a', { data: [true, { false: 3.0 }], weight: 2.6, label: 'unicode test ♥' });
   const v3 = g.createVertex(3.1415);
-  const v4 = g.createVertex({ 'what': -3 });
+  const v4 = g.createVertex('{ what: -3 }');
 
   g.createEdge(v1, v2, { label: 'label', weight: -0.1e14 });
   g.createEdge(v3, v4, { weight: 33 });

--- a/test/graph/vertex.test.mjs
+++ b/test/graph/vertex.test.mjs
@@ -16,14 +16,14 @@ describe('Vertex API', () => {
   });
 
   it('# Class should have a static fromJson method', function () {
-    let staticMethods = ['fromJson', 'fromJsonObject', 'isValidLabel', 'idFromLabel'];
+    let staticMethods = ['fromJson', 'fromJsonObject', 'isValidName', 'idFromName'];
     testStaticAPI(Vertex, staticMethods);
   });
 
   it('# Object\'s interface should be complete', () => {
     let vertex = new Vertex(1);
     let methods = ['constructor', 'equals', 'toJson', 'toJsonObject', 'toString', 'clone'];
-    let attributes = ['label', 'escapedLabel',  'id', 'weight'];
+    let attributes = ['name', 'escapedName',  'escapedLabel','id', 'weight'];
     testAPI(vertex, attributes, methods);
   });
 });
@@ -31,12 +31,12 @@ describe('Vertex API', () => {
 describe('Vertex Creation', () => {
   describe('# Parameters', () => {
     describe('# 1st argument (mandatory)', () => {
-      it('should throw when label is null or undefined', () => {
-        (() => new Vertex(null)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', null));
-        (() => new Vertex(undefined)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'label', undefined));
+      it('should throw when name is null or undefined', () => {
+        (() => new Vertex(null)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', null));
+        (() => new Vertex(undefined)).should.throw(ERROR_MSG_INVALID_ARGUMENT('Vertex()', 'name', undefined));
       });
 
-      it('should throw when label is not convetible to JSON', () => {
+      it('should throw when name is not convetible to JSON', () => {
         (() => new Vertex(new Map())).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Map()));
         (() => new Vertex(new Set())).should.throw(ERROR_MSG_INVALID_LABEL('Vertex()', new Set()));
       });
@@ -79,13 +79,13 @@ describe('Vertex Creation', () => {
 
 
 describe('Attributes', () => {
-  const labels = [1, '65.231', 'adbfhs', false, [], { a: 'x' }];
+  const names = [1, '65.231', 'adbfhs', false, [], { a: 'x' }];
 
-  describe('label', () => {
-    it('# should return the correct value for label', () => {
-      labels.forEach(label => {
-        let v = new Vertex(label, 1);
-        v.label.should.eql(label);
+  describe('name', () => {
+    it('# should return the correct value for name', () => {
+      names.forEach(name => {
+        let v = new Vertex(name, 1);
+        v.name.should.eql(name);
       });
     });
   });
@@ -94,7 +94,7 @@ describe('Attributes', () => {
     const weights = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'];
     it('# should return the correct weight', () => {
       weights.forEach(s => {
-        let v = new Vertex(choose(labels), { weight: s });
+        let v = new Vertex(choose(names), { weight: s });
         v.weight.should.eql(Number.parseFloat(s));
       });
     });
@@ -102,43 +102,43 @@ describe('Attributes', () => {
 });
 
 describe('Methods', () => {
-  const vertexLabels = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'];
-  const edgeLabels = ['', '1', '-1e14', 'test n° 1', 'unicode ☻'];
+  const vertexNames = [0, 1, -1, 3.1415, -2133, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, -13.12, '1', '-1e14'];
+  const edgeNames = ['', '1', '-1e14', 'test n° 1', 'unicode ☻'];
 
   describe('equals()', () => {
     it('# should return true if two edges are equals in all their fields', () => {
-      vertexLabels.forEach(label => {
+      vertexNames.forEach(name => {
         const weight = Math.random()
-        let v1 = new Vertex(label, { weight: weight });
-        let v2 = new Vertex(label, { weight: weight });
+        let v1 = new Vertex(name, { weight: weight });
+        let v2 = new Vertex(name, { weight: weight });
         v1.equals(v2).should.be.true();
       });
     });
 
     it('# should return false if the argument is not a Vertex', () => {
-      vertexLabels.forEach(label => {
+      vertexNames.forEach(name => {
         const weight = Math.random();
-        let v1 = new Vertex(label, { weight: weight });
-        v1.equals(choose(vertexLabels)).should.be.eql(false);
+        let v1 = new Vertex(name, { weight: weight });
+        v1.equals(choose(vertexNames)).should.be.eql(false);
       });
     });
 
-    it('# should return false if label is different', () => {
-      vertexLabels.forEach(label => {
-        const label2 = choose(vertexLabels);
+    it('# should return false if name is different', () => {
+      vertexNames.forEach(name => {
+        const name2 = choose(vertexNames);
         const weight = Math.random();
-        let v1 = new Vertex(label, { weight: weight });
-        let v2 = new Vertex(label2, { weight: weight });
-        v1.equals(v2).should.be.eql(Vertex.idFromLabel(label) === Vertex.idFromLabel(label2));
+        let v1 = new Vertex(name, { weight: weight });
+        let v2 = new Vertex(name2, { weight: weight });
+        v1.equals(v2).should.be.eql(Vertex.idFromName(name) === Vertex.idFromName(name2));
       });
     });
 
     it('# should return false if weight is different', () => {
-      vertexLabels.forEach(label => {
+      vertexNames.forEach(name => {
         const weight1 = Math.random();
         const weight2 = Math.random();
-        let v1 = new Vertex(label, { weight: weight1 });
-        let v2 = new Vertex(label, { weight: weight2 });
+        let v1 = new Vertex(name, { weight: weight1 });
+        let v2 = new Vertex(name, { weight: weight2 });
         v1.equals(v2).should.be.eql(weight1 === weight2);
       });
     });
@@ -146,8 +146,8 @@ describe('Methods', () => {
 
   describe('clone()', () => {
     it('# should clone the vertex fields', () => {
-      vertexLabels.forEach(label => {
-        let v = new Vertex(label);
+      vertexNames.forEach(name => {
+        let v = new Vertex(name);
         v.clone().id.should.eql(v.id);
         v.clone().equals(v).should.be.true();
       });
@@ -156,33 +156,33 @@ describe('Methods', () => {
     it('# changing the cloned instance should not affect the original', () => {
       let v = new Vertex({ 'test': 1 }, { weight: -3 });
       let w = v.clone();
-      v.label.should.eql(w.label);
+      v.name.should.eql(w.name);
       v.weight.should.eql(w.weight);
       v.equals(w).should.be.true();
       v.weight = 2;
-      v.label.should.eql(w.label);
+      v.name.should.eql(w.name);
       v.equals(w).should.be.not.true();
     });
   });
 
   describe('toJson()', () => {
     it('# should return a valid json', () => {
-      Vertex.isValidLabel(new Vertex('test')).should.be.true();
-      vertexLabels.forEach(label => {
-        let v = new Vertex(label, { weight: Math.random() });
+      Vertex.isValidName(new Vertex('test')).should.be.true();
+      vertexNames.forEach(name => {
+        let v = new Vertex(name, { weight: Math.random() });
         expect(() => JSON.parse(v.toJson())).not.to.throw();
       });
     });
 
     it('# should stringify the fields consistently and deep-stringify all the fields', () => {
       let v = new Vertex({ 'test': ['abc', 1, 3] }, { weight: 3.14 });
-      v.toJson().should.eql('{"label":{"test":["abc",1,3]},"weight":3.14}');
+      v.toJson().should.eql('{"name":{"test":["abc",1,3]},"weight":3.14}');
     });
   });
 
   describe('fromJson()', () => {
     it('# applyed to the result of toJson, it should match source vertex', () => {
-      vertexLabels.forEach(source => {
+      vertexNames.forEach(source => {
         let v = new Vertex(source, { weight: Math.random() });
         Vertex.fromJsonObject(JSON.parse(v.toJson())).should.eql(v);
       });

--- a/test/graph/vertex.test.mjs
+++ b/test/graph/vertex.test.mjs
@@ -16,14 +16,14 @@ describe('Vertex API', () => {
   });
 
   it('# Class should have a static fromJson method', function () {
-    let staticMethods = ['fromJson', 'fromJsonObject', 'isValidName', 'idFromName'];
+    let staticMethods = ['fromJson', 'fromJsonObject', 'isValidName', 'isValidLabel', 'isValidData', 'idFromName'];
     testStaticAPI(Vertex, staticMethods);
   });
 
   it('# Object\'s interface should be complete', () => {
     let vertex = new Vertex(1);
-    let methods = ['constructor', 'equals', 'toJson', 'toJsonObject', 'toString', 'clone'];
-    let attributes = ['name', 'escapedName',  'escapedLabel','id', 'weight'];
+    let methods = ['constructor', 'hasLabel', 'hasData', 'equals', 'toJson', 'toJsonObject', 'toString', 'clone'];
+    let attributes = ['name', 'id', 'label', 'data', 'escapedName', 'escapedLabel', 'weight'];
     testAPI(vertex, attributes, methods);
   });
 });
@@ -84,7 +84,7 @@ describe('Attributes', () => {
   describe('name', () => {
     it('# should return the correct value for name', () => {
       names.forEach(name => {
-        let v = new Vertex(name, 1);
+        const v = new Vertex(name);
         v.name.should.eql(name);
       });
     });
@@ -96,6 +96,57 @@ describe('Attributes', () => {
       weights.forEach(s => {
         let v = new Vertex(choose(names), { weight: s });
         v.weight.should.eql(Number.parseFloat(s));
+      });
+    });
+  });
+
+  describe('label', () => {
+    it('# should be undefined when not set', () => {
+      const v = new Vertex('v', {weight: 2, data: ['data']});
+      v.hasLabel().should.be.false();
+      expect(v.label).to.be.undefined;
+    });
+
+    it('# should return the correct value for data when defined', () => {
+      ['a', 'test label', 'unicode ☺'].forEach(label => {
+        const v = new Vertex('v', {label: label});
+        v.hasLabel().should.be.true();
+        v.label.should.eql(label);
+      });
+    });
+
+    it('# should be set correctly', () => {
+      const v = new Vertex('v');
+      v.hasLabel().should.be.false();
+      expect(v.label).to.be.undefined;
+      v.label = 'test';
+      v.label.should.eql('test');
+    });
+  });
+
+  describe('data', () => {
+    it('# should be undefined when not set', () => {
+      const v = new Vertex('v', {weight: 2, label: 'lab'});
+      v.hasData().should.be.false();
+      expect(v.data).to.be.undefined;
+    });
+
+    it('# should return the correct value for data when defined', () => {
+      names.forEach(data => {
+        let v = new Vertex('v', {data: data});
+        v.hasData().should.be.true();
+        v.data.should.eql(data);
+      });
+    });
+
+    it('# should be set correctly', () => {
+      const v = new Vertex('v');
+      v.hasData().should.be.false();
+      expect(v.data).to.be.undefined;
+      names.forEach(data => {
+        v.data = data;
+        v.hasData().should.be.true();
+        v.data.should.eql(data);
       });
     });
   });
@@ -177,6 +228,8 @@ describe('Methods', () => {
     it('# should stringify the fields consistently and deep-stringify all the fields', () => {
       let v = new Vertex({ 'test': ['abc', 1, 3] }, { weight: 3.14 });
       v.toJson().should.eql('{"name":{"test":["abc",1,3]},"weight":3.14}');
+      v = new Vertex({ 'test': ['abc', 1, 3] }, { weight: -3.14, data: ['123', 'a'], label: "test" });
+      JSON.parse(v.toJson()).should.eql({ "name": { "test": ["abc", 1, 3] }, "weight": -3.14, label: "test", data: ['123', 'a'] });
     });
   });
 
@@ -189,7 +242,7 @@ describe('Methods', () => {
     });
 
     it('# should parse the fields consistently and deep-parse all the fields', () => {
-      let v = new Vertex('abc', { weight: 3.14 });
+      let v = new Vertex('abc', { weight: 3.14, data: ['123', { 'a': [1, 2, 3], 'b': { 1: 1 } }], label: "test" });
       Vertex.fromJsonObject(JSON.parse(v.toJson())).should.eql(v);
     });
   });


### PR DESCRIPTION
Breaking changes:
- Renamed Vertex.label -> Vertex.name
- Vertex.name (once label) now can only hold strings or numbers
- Graph getter for Vertex/Edge's weight now throws if the vertex passed is not in the graph

Additive changes:
- New optional Vertex.label field, strings only
- New optional Vertex.data field, can hold any serializable data